### PR TITLE
Fix A-10 radio preset validation

### DIFF
--- a/JAFDTC/UI/A10C/A10CEditRadioPageHelper.cs
+++ b/JAFDTC/UI/A10C/A10CEditRadioPageHelper.cs
@@ -209,5 +209,8 @@ namespace JAFDTC.UI.F16C
 
         public int RadioPresetCount(int radio, IConfiguration config)
             => ((A10CConfiguration)config).Radio.Presets[radio].Count;
+
+        public override bool ValidateFrequency(int radio, string freq, bool isNoEValid = true)
+            => RadioSystem.IsFreqValidForRadio((RadioSystem.Radios)radio, freq, isNoEValid);
     }
 }


### PR DESCRIPTION
Proper validation of A-10 radio presets got lost [in this change](https://github.com/51st-Vfw/JAFDTC/commit/2ec908a88c9ff55fea14f3d116875ed10ecd0fb3#diff-b949cdc9f27cc9659b1cf1f13de61f2fe3dcbdec9fc874be1b9c98b18c1b5287L219), when `RadioPageHelperBase` was expanded. This puts it back.