### PR TITLE
Don't pass nil to JSON:decode in JAFDTC.lua

### DIFF
--- a/JAFDTC/DCS/JAFDTC/JAFDTC.lua
+++ b/JAFDTC/DCS/JAFDTC/JAFDTC.lua
@@ -298,13 +298,15 @@ function LuaExportBeforeNextFrame()
     if curTime >= cmdResumeTime then
         if not cmdList then
             local data = JAFDTC_TCPServerSockRx(tcpCmdServerSock)
-            cmdCurProgress = 0
-            cmdListIndex = 1
-            cmdList = JSON:decode(data)
-            if not cmdList and data then
-                JAFDTC_Log(string.format("[%.3f] ERROR: JSON decode failed", curTime))
-            elseif cmdList and data then
-                JAFDTC_Log(string.format("[%.3f] Process rx cmdList[1:%d] %dB", curTime, #cmdList, string.len(data)))
+            if data then
+                cmdCurProgress = 0
+                cmdListIndex = 1
+                cmdList = JSON:decode(data)
+                if not cmdList and data then
+                    JAFDTC_Log(string.format("[%.3f] ERROR: JSON decode failed", curTime))
+                elseif cmdList and data then
+                    JAFDTC_Log(string.format("[%.3f] Process rx cmdList[1:%d] %dB", curTime, #cmdList, string.len(data)))
+                end
             end
         end
 


### PR DESCRIPTION
Fixes this error in DCS.log by not calling `JSON:decode()` with nil `data`.

```
2024-04-27 16:48:53.178 ERROR   Lua::Config (Main): Call error LuaExportBeforeNextFrame:[string "Scripts\JSON.lua"]:240: nil passed to JSON:decode()
stack traceback:
	[C]: ?
	[C]: in function 'assert'
	[string "Scripts\JSON.lua"]:240: in function 'onDecodeOfNilError'
	[string "Scripts\JSON.lua"]:497: in function 'decode'
	[string "F:\Saved Games\DCS\Scripts/JAFDTC/JAFDTC.lua"]:303: in function <[string "F:\Saved Games\DCS\Scripts/JAFDTC/JAFDTC.lua"]:294>.
2024-04-27 16:48:53.876 WARNING LOG (4624): 113 duplicate message(s) skipped.
```