### PR TITLE
Do not include decimal when setting ARC-210 presets

### DIFF
--- a/JAFDTC/Models/A10C/A10CDeviceManager.cs
+++ b/JAFDTC/Models/A10C/A10CDeviceManager.cs
@@ -52,6 +52,7 @@ namespace JAFDTC.Models.A10C
             cdu.AddAction(3022, "8", delayChar, 1);
             cdu.AddAction(3023, "9", delayChar, 1);
             cdu.AddAction(3024, "0", delayChar, 1);
+            cdu.AddAction(3025, ".", delayChar, 1);
             cdu.AddAction(3027, "A", delayChar, 1);
             cdu.AddAction(3028, "B", delayChar, 1);
             cdu.AddAction(3029, "C", delayChar, 1);

--- a/JAFDTC/Models/A10C/Upload/RadioBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/RadioBuilder.cs
@@ -239,7 +239,7 @@ namespace JAFDTC.Models.A10C.Upload
             AddActions(cdu, new() { "CLR", "CLR" }, ActionsForString(AdjustOnlyAlphaNum(descr)));
             AddAction(rmfd, "RMFD_16");
 
-            AddActions(cdu, new() { "CLR", "CLR" }, ActionsForString(preset.Frequency));
+            AddActions(cdu, new() { "CLR", "CLR" }, ActionsForString(AdjustNoSeparators(preset.Frequency)));
             AddAction(rmfd, "RMFD_17");
 
             if (!RadioSystem.IsModulationDefaultForFreq(RadioSystem.Radios.COMM1, preset.Frequency, preset.Modulation))


### PR DESCRIPTION
I noticed this in jafdtc-log.txt:

```
Action CDU.. is undefined
```

It is correct to not include the decimal button when setting an ARC-210 preset on the COMM page in the A-10, but we were doing it by accident because the decimal key is undefined on the CDU.

This adds the definition for the CDU decimal key for future use and deliberately strips the decimal from the preset string so this continues to work.