### PR TITLE
A10: Allow blank altitude for ground-level waypoints.

### DIFF
--- a/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
+++ b/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
@@ -22,14 +22,20 @@ You should have received a copy of the GNU General Public License along with thi
 dofile(lfs.writedir() .. 'Scripts/JAFDTC/CommonFunctions.lua')
 
 function JAFDTC_A10C_GetCDU()
-	return JAFDTC_ParseDisplay(3)
+	local table = JAFDTC_ParseDisplay(3)
+    JAFDTC_DebugDisplay(table);
+    return table;
+end
+
+function JAFDTC_A10C_GetCDU_value(key)
+	local table = JAFDTC_A10C_GetCDU();
+    local value = table[key] or "---";
+    JAFDTC_Log("CDU table[" .. key .. "]: " .. value);
+    return value
 end
 
 function JAFDTC_A10C_CheckCondition_IsCoordFmtLL()
-    local table = JAFDTC_A10C_GetCDU();
-    JAFDTC_DebugDisplay(table);
-    local value = table["WAYPTCoordFormat"] or "---";
-    JAFDTC_Log("table value: " .. value);
+    local value = JAFDTC_A10C_GetCDU_value("WAYPTCoordFormat");
     if string.sub(value, 1, 3) == "L/L" then
         return true
     end
@@ -37,10 +43,7 @@ function JAFDTC_A10C_CheckCondition_IsCoordFmtLL()
 end
 
 function JAFDTC_A10C_CheckCondition_IsCoordFmtNotLL()
-    local table = JAFDTC_A10C_GetCDU();
-    JAFDTC_DebugDisplay(table);
-    local value = table["WAYPTCoordFormat"] or "---";
-    JAFDTC_Log("table value: " .. value);
+    local value = JAFDTC_A10C_GetCDU_value("WAYPTCoordFormat");
     if string.sub(value, 1, 3) ~= "L/L" then
         return true
     end
@@ -48,14 +51,26 @@ function JAFDTC_A10C_CheckCondition_IsCoordFmtNotLL()
 end
 
 function JAFDTC_A10C_CheckCondition_IsBullsNotOnHUD()
-    local table = JAFDTC_A10C_GetCDU();
-    JAFDTC_DebugDisplay(table);
-    local value = table["HUD_OFF"] or "---";
-    JAFDTC_Log("table value: " .. value);
+    local value = JAFDTC_A10C_GetCDU_value("HUD_OFF");
     if value == "OFF" then
         return true
     end
     return false
+end
+
+function JAFDTC_A10C_CheckCondition_SpeedIsNot(speed)
+    JAFDTC_Log("SpeedIsNot(" .. speed .. ")");
+    local table = JAFDTC_A10C_GetCDU();
+    if speed == "IAS" then
+        return table["STRSpeedMode4"] ~= "IAS"
+    end
+    if speed == "TAS" then
+        return table["STRSpeedMode5"] ~= "TAS"
+    end
+    if speed == "GS" then
+        return table["STRSpeedMode6"] ~= "GS"
+    end
+    return true
 end
 
 --[[

--- a/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
+++ b/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
@@ -21,8 +21,19 @@ You should have received a copy of the GNU General Public License along with thi
 
 dofile(lfs.writedir() .. 'Scripts/JAFDTC/CommonFunctions.lua')
 
+-- Displays
+-----------
+-- 1: LMFD
+-- 2: RMFD
+-- 3: CDU
+-- 4: ?
+-- 5: HUD
+-- 6: ?
+-- 7: CMS (countmeasures panel on right)
+-- 8: CMSC (countermeasure and jammer display below UFC)
+
 function JAFDTC_A10C_GetCDU()
-	local table = JAFDTC_ParseDisplay(3)
+	local table = JAFDTC_ParseDisplay(3);
     JAFDTC_DebugDisplay(table);
     return table;
 end
@@ -31,7 +42,7 @@ function JAFDTC_A10C_GetCDU_value(key)
 	local table = JAFDTC_A10C_GetCDU();
     local value = table[key] or "---";
     JAFDTC_Log("CDU table[" .. key .. "]: " .. value);
-    return value
+    return value;
 end
 
 function JAFDTC_A10C_CheckCondition_IsCoordFmtLL()

--- a/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
+++ b/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
@@ -66,6 +66,16 @@ function JAFDTC_A10C_CheckCondition_IsFlightPlanNotManual()
     return false
 end
 
+function JAFDTC_A10C_CheckCondition_SpeedIsAvailable()
+    local table = JAFDTC_A10C_GetCDU();
+    return table["STRSpeedMode4"] == "IAS" or table["STRSpeedMode5"] == "TAS" or table["STRSpeedMode6"] == "GS"
+end
+
+function JAFDTC_A10C_CheckCondition_SpeedIsNotAvailable()
+    local table = JAFDTC_A10C_GetCDU();
+    return table["STRSpeedMode4"] ~= "IAS" and table["STRSpeedMode5"] ~= "TAS" and table["STRSpeedMode6"] ~= "GS"
+end
+
 function JAFDTC_A10C_CheckCondition_SpeedIsNot(speed)
     JAFDTC_Log("SpeedIsNot(" .. speed .. ")");
     local table = JAFDTC_A10C_GetCDU();

--- a/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
+++ b/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
@@ -58,6 +58,14 @@ function JAFDTC_A10C_CheckCondition_IsBullsNotOnHUD()
     return false
 end
 
+function JAFDTC_A10C_CheckCondition_IsFlightPlanNotManual()
+    local value = JAFDTC_A10C_GetCDU_value("FPMode");
+    if value ~= "MAN" then
+        return true
+    end
+    return false
+end
+
 function JAFDTC_A10C_CheckCondition_SpeedIsNot(speed)
     JAFDTC_Log("SpeedIsNot(" .. speed .. ")");
     local table = JAFDTC_A10C_GetCDU();

--- a/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
+++ b/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
@@ -27,7 +27,9 @@ end
 
 function JAFDTC_A10C_CheckCondition_IsCoordFmtLL()
     local table = JAFDTC_A10C_GetCDU();
+    JAFDTC_DebugDisplay(table);
     local value = table["WAYPTCoordFormat"] or "---";
+    JAFDTC_Log("table value: " .. value);
     if string.sub(value, 1, 3) == "L/L" then
         return true
     end
@@ -36,9 +38,21 @@ end
 
 function JAFDTC_A10C_CheckCondition_IsCoordFmtNotLL()
     local table = JAFDTC_A10C_GetCDU();
+    JAFDTC_DebugDisplay(table);
     local value = table["WAYPTCoordFormat"] or "---";
+    JAFDTC_Log("table value: " .. value);
     if string.sub(value, 1, 3) ~= "L/L" then
-        JAFDTC_DebugDisplay(table)
+        return true
+    end
+    return false
+end
+
+function JAFDTC_A10C_CheckCondition_IsBullsNotOnHUD()
+    local table = JAFDTC_A10C_GetCDU();
+    JAFDTC_DebugDisplay(table);
+    local value = table["HUD_OFF"] or "---";
+    JAFDTC_Log("table value: " .. value);
+    if value == "OFF" then
         return true
     end
     return false

--- a/JAFDTC/JAFDTC.csproj
+++ b/JAFDTC/JAFDTC.csproj
@@ -48,6 +48,7 @@
     <None Remove="Images\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <None Remove="Images\Wide310x150Logo.scale-200.png" />
     <None Remove="Package.appxmanifest" />
+    <None Remove="UI\A10C\A10CEditMiscPage.xaml" />
     <None Remove="UI\App\EditPointsOfInterestPage.xaml" />
     <None Remove="UI\App\ImportParamsDialog.xaml" />
     <None Remove="UI\AV8B\AV8BEditWaypointListPage.xaml" />
@@ -127,6 +128,12 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Update="UI\A10C\A10CEditMiscPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
 
   <ItemGroup>

--- a/JAFDTC/Models/A10C/A10CConfiguration.cs
+++ b/JAFDTC/Models/A10C/A10CConfiguration.cs
@@ -17,6 +17,7 @@
 //
 // ********************************************************************************************************************
 
+using JAFDTC.Models.A10C.Misc;
 using JAFDTC.Models.A10C.Radio;
 using JAFDTC.Models.A10C.WYPT;
 using JAFDTC.UI.A10C;
@@ -43,7 +44,9 @@ namespace JAFDTC.Models.A10C
         // properties
         //
         // ------------------------------------------------------------------------------------------------------------
-
+        
+        public MiscSystem Misc { get; set; }
+        
         public RadioSystem Radio { get; set; }
 
         public WYPTSystem WYPT { get; set; }
@@ -60,6 +63,7 @@ namespace JAFDTC.Models.A10C
         public A10CConfiguration(string uid, string name, Dictionary<string, string> linkedSysMap)
             : base(_versionCfg, AirframeTypes.A10C, uid, name, linkedSysMap)
         {
+            Misc = new MiscSystem();
             Radio = new RadioSystem();
             WYPT = new WYPTSystem();
             ConfigurationUpdated();
@@ -74,6 +78,7 @@ namespace JAFDTC.Models.A10C
             }
             A10CConfiguration clone = new(UID, Name, linkedSysMap)
             {
+                Misc = (MiscSystem)Misc.Clone(),
                 Radio = (RadioSystem)Radio.Clone(),
                 WYPT = (WYPTSystem)WYPT.Clone(),
             };
@@ -86,6 +91,7 @@ namespace JAFDTC.Models.A10C
             A10CConfiguration otherHawg = (A10CConfiguration)other;
             switch (systemTag)
             {
+                case MiscSystem.SystemTag: Misc = (MiscSystem)otherHawg.Misc.Clone(); break;
                 case RadioSystem.SystemTag: Radio = (RadioSystem)otherHawg.Radio.Clone(); break;
                 case WYPTSystem.SystemTag: WYPT = (WYPTSystem)otherHawg.WYPT.Clone(); break;
                 default: break;
@@ -118,6 +124,7 @@ namespace JAFDTC.Models.A10C
             return systemTag switch
             {
                 null => JsonSerializer.Serialize(this, Configuration.JsonOptions),
+                MiscSystem.SystemTag => JsonSerializer.Serialize(Misc, Configuration.JsonOptions),
                 RadioSystem.SystemTag => JsonSerializer.Serialize(Radio, Configuration.JsonOptions),
                 WYPTSystem.SystemTag => JsonSerializer.Serialize(WYPT, Configuration.JsonOptions),
                 _ => null
@@ -126,6 +133,7 @@ namespace JAFDTC.Models.A10C
 
         public override void AfterLoadFromJSON()
         {
+            Misc ??= new MiscSystem();
             Radio ??= new RadioSystem();
             WYPT ??= new WYPTSystem();
 
@@ -138,10 +146,11 @@ namespace JAFDTC.Models.A10C
 
         public override bool CanAcceptPasteForSystem(string cboardTag, string systemTag = null)
         {
-            return (!string.IsNullOrEmpty(cboardTag) &&
-                    (((systemTag != null) && (cboardTag.StartsWith(systemTag))) ||
-                     ((systemTag == null) && ((cboardTag == RadioSystem.SystemTag))) ||
-                     ((systemTag == null) && ((cboardTag == WYPTSystem.SystemTag)))));
+            return !string.IsNullOrEmpty(cboardTag) &&
+                   (((systemTag != null) && (cboardTag.StartsWith(systemTag))) ||
+                   ((systemTag == null) && (cboardTag == MiscSystem.SystemTag)) ||
+                   ((systemTag == null) && (cboardTag == RadioSystem.SystemTag)) ||
+                   ((systemTag == null) && (cboardTag == WYPTSystem.SystemTag)));
         }
 
         public override bool Deserialize(string systemTag, string json)
@@ -152,6 +161,7 @@ namespace JAFDTC.Models.A10C
             {
                 switch (systemTag)
                 {
+                    case MiscSystem.SystemTag: Misc = JsonSerializer.Deserialize<MiscSystem>(json); break;
                     case RadioSystem.SystemTag: Radio = JsonSerializer.Deserialize<RadioSystem>(json); break;
                     case WYPTSystem.SystemTag: WYPT = JsonSerializer.Deserialize<WYPTSystem>(json); break;
                     default: isHandled = false; break;

--- a/JAFDTC/Models/A10C/A10CConfiguration.cs
+++ b/JAFDTC/Models/A10C/A10CConfiguration.cs
@@ -23,7 +23,6 @@ using JAFDTC.Models.A10C.WYPT;
 using JAFDTC.UI.A10C;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Text.Json.Serialization;
 using System.Text.Json;
 using JAFDTC.Utilities;

--- a/JAFDTC/Models/A10C/A10CDeviceManager.cs
+++ b/JAFDTC/Models/A10C/A10CDeviceManager.cs
@@ -88,6 +88,7 @@ namespace JAFDTC.Models.A10C
             cdu.AddAction(3006, "LSK_5R", delay, 1);
             cdu.AddAction(3007, "LSK_7R", delay, 1);
             cdu.AddAction(3008, "LSK_9R", delay, 1);
+            cdu.AddAction(3010, "NAV", delay, 1);
             cdu.AddAction(3011, "WP", delay, 1);
             AddDevice(cdu);
 

--- a/JAFDTC/Models/A10C/A10CDeviceManager.cs
+++ b/JAFDTC/Models/A10C/A10CDeviceManager.cs
@@ -110,6 +110,13 @@ namespace JAFDTC.Models.A10C
 
             AddDevice(aap);
 
+            // ---- Autopilot (LASTE) panel
+
+            AirframeDevice ap = new(38, "AUTOPILOT");
+            ap.AddAction(3001, "AP_MODE", delay, 0); // -1 down, 0 mid, 1 up
+            AddDevice(ap);
+
+
             // ---- left mfd
 
             AirframeDevice lmfd = new(2, "LMFD");

--- a/JAFDTC/Models/A10C/A10CDeviceManager.cs
+++ b/JAFDTC/Models/A10C/A10CDeviceManager.cs
@@ -91,6 +91,7 @@ namespace JAFDTC.Models.A10C
             cdu.AddAction(3008, "LSK_9R", delay, 1);
             cdu.AddAction(3010, "NAV", delay, 1);
             cdu.AddAction(3011, "WP", delay, 1);
+            cdu.AddAction(3013, "FPM", delay, 1);
             AddDevice(cdu);
 
             // ---- left mfd

--- a/JAFDTC/Models/A10C/A10CDeviceManager.cs
+++ b/JAFDTC/Models/A10C/A10CDeviceManager.cs
@@ -94,6 +94,22 @@ namespace JAFDTC.Models.A10C
             cdu.AddAction(3013, "FPM", delay, 1);
             AddDevice(cdu);
 
+            // ---- auxiliary avionics panel
+            AirframeDevice aap = new(22, "AAP");
+
+            // steer pt selection knob
+            aap.AddAction(3001, "STEER_FLT_PLAN", delay, 0.0, 0.0);
+            aap.AddAction(3001, "STEER_MARK", delay, 0.1, 0.1);
+            aap.AddAction(3001, "STEER_MISSION", delay, 0.2, 0.2);
+
+            // CDU page selection knob
+            aap.AddAction(3004, "PAGE_OTHER", delay, 0.0, 0.0);
+            aap.AddAction(3004, "PAGE_POSITION", delay, 0.1, 0.1);
+            aap.AddAction(3004, "PAGE_STEER", delay, 0.2, 0.2);
+            aap.AddAction(3004, "PAGE_WAYPT", delay, 0.3, 0.3);
+
+            AddDevice(aap);
+
             // ---- left mfd
 
             AirframeDevice lmfd = new(2, "LMFD");

--- a/JAFDTC/Models/A10C/A10CDeviceManager.cs
+++ b/JAFDTC/Models/A10C/A10CDeviceManager.cs
@@ -163,6 +163,8 @@ namespace JAFDTC.Models.A10C
             ufc.AddAction(3008, "8", delay, 1);
             ufc.AddAction(3009, "9", delay, 1);
             ufc.AddAction(3010, "0", delay, 1);
+            ufc.AddAction(3011, "SPC", delay, 1);
+            ufc.AddAction(3013, "FN", delay, 1);
             AddDevice(ufc);
 
             // ---- an/arc-210 uhf radio

--- a/JAFDTC/Models/A10C/A10CUploadAgent.cs
+++ b/JAFDTC/Models/A10C/A10CUploadAgent.cs
@@ -93,6 +93,7 @@ namespace JAFDTC.Models.A10C
         {
             new RadioBuilder(_cfg, _dcsCmds, sb).Build();
             new WYPTBuilder(_cfg, _dcsCmds, sb).Build();
+            new MiscBuilder(_cfg, _dcsCmds, sb).Build();
         }
 
         public override IBuilder TeardownBuilder(StringBuilder sb) => new A10CTeardownBuilder(_cfg, _dcsCmds, sb);

--- a/JAFDTC/Models/A10C/Misc/MiscSystem.cs
+++ b/JAFDTC/Models/A10C/Misc/MiscSystem.cs
@@ -49,6 +49,25 @@ namespace JAFDTC.Models.A10C.Misc
         GND = 2
     }
 
+    // defines the aap steer pt knob options
+    //
+    public enum AapSteerPtOptions
+    {
+        FltPlan = 0,
+        Mark = 1,
+        Mission = 2
+    }
+
+    // defines the aap page options
+    //
+    public enum AapPageOptions
+    {
+        Other = 0,
+        Position = 1,
+        Steer = 2,
+        Waypt = 3
+    }
+
     /// <summary>
     /// TODO: document
     /// </summary>
@@ -108,6 +127,28 @@ namespace JAFDTC.Models.A10C.Misc
             }
         }
 
+        private string _aapSteerPt;                              // integer [0, 1, 2]
+        public string AapSteerPt
+        {
+            get => _aapSteerPt;
+            set
+            {
+                string error = (string.IsNullOrEmpty(value) || IsIntegerFieldValid(value, 0, 2)) ? null : "Invalid format";
+                SetProperty(ref _aapSteerPt, value, error);
+            }
+        }
+
+        private string _aapPage;                              // integer [0, 1, 2, 3]
+        public string AapPage
+        {
+            get => _aapPage;
+            set
+            {
+                string error = (string.IsNullOrEmpty(value) || IsIntegerFieldValid(value, 0, 3)) ? null : "Invalid format";
+                SetProperty(ref _aapPage, value, error);
+            }
+        }
+
         // ---- following properties are synthesized
 
         // returns a MiscSystem with the fields populated with the actual default values (note that usually the value
@@ -121,6 +162,8 @@ namespace JAFDTC.Models.A10C.Misc
             BullseyeOnHUD = false.ToString(),
             FlightPlan1Manual = "0", // Auto
             SpeedDisplay = "0", // IAS
+            AapSteerPt = "0", // Flt Plan
+            AapPage = "0", // Other
         };
 
         // returns true if the instance indicates a default setup (all fields are "") or the object is in explicit
@@ -129,7 +172,8 @@ namespace JAFDTC.Models.A10C.Misc
         [JsonIgnore]
         public bool IsDefault
         {
-            get => IsCoordSystemDefault && IsBullseyeOnHUDDefault && IsFlightPlan1ManualDefault;
+            get => IsCoordSystemDefault && IsBullseyeOnHUDDefault && IsFlightPlan1ManualDefault
+                   && IsAapSteerPtDefault && IsAapPageDefault;
         }
 
         [JsonIgnore]
@@ -156,6 +200,17 @@ namespace JAFDTC.Models.A10C.Misc
             get => string.IsNullOrEmpty(SpeedDisplay) || SpeedDisplay == ExplicitDefaults.SpeedDisplay;
         }
 
+        [JsonIgnore]
+        public bool IsAapSteerPtDefault
+        {
+            get => string.IsNullOrEmpty(AapSteerPt) || AapSteerPt == ExplicitDefaults.AapSteerPt;
+        }
+
+        [JsonIgnore]
+        public bool IsAapPageDefault
+        {
+            get => string.IsNullOrEmpty(AapPage) || AapPage == ExplicitDefaults.AapPage;
+        }
 
         // ---- following accessors get the current value (default or non-default) for various properties
 
@@ -183,6 +238,18 @@ namespace JAFDTC.Models.A10C.Misc
             get => (SpeedDisplayOptions)int.Parse((string.IsNullOrEmpty(SpeedDisplay)) ? ExplicitDefaults.SpeedDisplay : SpeedDisplay);
         }
 
+        [JsonIgnore]
+        public AapSteerPtOptions AapSteerPtValue
+        {
+            get => (AapSteerPtOptions)int.Parse((string.IsNullOrEmpty(AapSteerPt)) ? ExplicitDefaults.AapSteerPt : AapSteerPt);
+        }
+
+        [JsonIgnore]
+        public AapPageOptions AapPageValue
+        {
+            get => (AapPageOptions)int.Parse((string.IsNullOrEmpty(AapPage)) ? ExplicitDefaults.AapPage : AapPage);
+        }
+
         // ------------------------------------------------------------------------------------------------------------
         //
         // construction
@@ -200,6 +267,8 @@ namespace JAFDTC.Models.A10C.Misc
             BullseyeOnHUD = new(other.BullseyeOnHUD);
             FlightPlan1Manual = new(other.FlightPlan1Manual);
             SpeedDisplay = new(other.SpeedDisplay);
+            AapSteerPt = new(other.AapSteerPt);
+            AapPage = new(other.AapPage);
          }
 
         public virtual object Clone() => new MiscSystem(this);
@@ -218,6 +287,8 @@ namespace JAFDTC.Models.A10C.Misc
             BullseyeOnHUD = "";
             FlightPlan1Manual = "";
             SpeedDisplay = "";
+            AapSteerPt = "";
+            AapPage = "";
          }
     }
 }

--- a/JAFDTC/Models/A10C/Misc/MiscSystem.cs
+++ b/JAFDTC/Models/A10C/Misc/MiscSystem.cs
@@ -68,6 +68,15 @@ namespace JAFDTC.Models.A10C.Misc
         Waypt = 3
     }
 
+    // defines the autopilot mode options
+    //
+    public enum AutopilotModeOptions
+    {
+        Alt = -1,
+        AltHdg = 0,
+        Path = 1
+    }
+
     /// <summary>
     /// TODO: document
     /// </summary>
@@ -149,6 +158,17 @@ namespace JAFDTC.Models.A10C.Misc
             }
         }
 
+        private string _autopilotMode;                              // integer [-1, 0, 1]
+        public string AutopilotMode
+        {
+            get => _autopilotMode;
+            set
+            {
+                string error = (string.IsNullOrEmpty(value) || IsIntegerFieldValid(value, -1, 1)) ? null : "Invalid format";
+                SetProperty(ref _autopilotMode, value, error);
+            }
+        }
+
         // ---- following properties are synthesized
 
         // returns a MiscSystem with the fields populated with the actual default values (note that usually the value
@@ -164,6 +184,7 @@ namespace JAFDTC.Models.A10C.Misc
             SpeedDisplay = "0", // IAS
             AapSteerPt = "0", // Flt Plan
             AapPage = "0", // Other
+            AutopilotMode = "0" // Alt/Hdg
         };
 
         // returns true if the instance indicates a default setup (all fields are "") or the object is in explicit
@@ -173,7 +194,8 @@ namespace JAFDTC.Models.A10C.Misc
         public bool IsDefault
         {
             get => IsCoordSystemDefault && IsBullseyeOnHUDDefault && IsFlightPlan1ManualDefault
-                   && IsSpeedDisplayDefault && IsAapSteerPtDefault && IsAapPageDefault;
+                && IsSpeedDisplayDefault && IsAapSteerPtDefault && IsAapPageDefault 
+                && IsAutopilotModeDefault;
         }
 
         [JsonIgnore]
@@ -210,6 +232,12 @@ namespace JAFDTC.Models.A10C.Misc
         public bool IsAapPageDefault
         {
             get => string.IsNullOrEmpty(AapPage) || AapPage == ExplicitDefaults.AapPage;
+        }
+
+        [JsonIgnore]
+        public bool IsAutopilotModeDefault
+        {
+            get => string.IsNullOrEmpty(AutopilotMode) || AutopilotMode == ExplicitDefaults.AutopilotMode;
         }
 
         // ---- following accessors get the current value (default or non-default) for various properties
@@ -250,6 +278,12 @@ namespace JAFDTC.Models.A10C.Misc
             get => (AapPageOptions)int.Parse((string.IsNullOrEmpty(AapPage)) ? ExplicitDefaults.AapPage : AapPage);
         }
 
+        [JsonIgnore]
+        public AutopilotModeOptions AutopilotModeValue
+        {
+            get => (AutopilotModeOptions)int.Parse((string.IsNullOrEmpty(AutopilotMode)) ? ExplicitDefaults.AutopilotMode : AutopilotMode);
+        }
+
         // ------------------------------------------------------------------------------------------------------------
         //
         // construction
@@ -269,6 +303,7 @@ namespace JAFDTC.Models.A10C.Misc
             SpeedDisplay = new(other.SpeedDisplay);
             AapSteerPt = new(other.AapSteerPt);
             AapPage = new(other.AapPage);
+            AutopilotMode = new(other.AutopilotMode);
          }
 
         public virtual object Clone() => new MiscSystem(this);
@@ -289,6 +324,7 @@ namespace JAFDTC.Models.A10C.Misc
             SpeedDisplay = "";
             AapSteerPt = "";
             AapPage = "";
+            AutopilotMode = "";
          }
     }
 }

--- a/JAFDTC/Models/A10C/Misc/MiscSystem.cs
+++ b/JAFDTC/Models/A10C/Misc/MiscSystem.cs
@@ -66,6 +66,17 @@ namespace JAFDTC.Models.A10C.Misc
             }
         }
 
+        private string _bullseyeOnHUD;                           // string (boolean)
+        public string BullseyeOnHUD
+        {
+            get => _bullseyeOnHUD;
+            set
+            {
+                string error = (string.IsNullOrEmpty(value) || IsBooleanFieldValid(value)) ? null : "Invalid format";
+                SetProperty(ref _bullseyeOnHUD, value, error);
+            }
+        }
+
         private string _flightPlan1Manual;                              // integer [0, 1]
         public string FlightPlan1Manual
         {
@@ -87,6 +98,7 @@ namespace JAFDTC.Models.A10C.Misc
         public readonly static MiscSystem ExplicitDefaults = new()
         {
             CoordSystem = "0", // Lat/Long
+            BullseyeOnHUD = false.ToString(),
             FlightPlan1Manual = "0" // Auto
         };
 
@@ -96,13 +108,19 @@ namespace JAFDTC.Models.A10C.Misc
         [JsonIgnore]
         public bool IsDefault
         {
-            get => IsCoordSystemDefault && IsFlightPlan1ManualDefault;
+            get => IsCoordSystemDefault && IsBullseyeOnHUDDefault && IsFlightPlan1ManualDefault;
         }
 
         [JsonIgnore]
         public bool IsCoordSystemDefault
         {
             get => string.IsNullOrEmpty(CoordSystem) || CoordSystem == ExplicitDefaults.CoordSystem;
+        }
+
+        [JsonIgnore]
+        public bool IsBullseyeOnHUDDefault
+        {
+            get => string.IsNullOrEmpty(BullseyeOnHUD) || BullseyeOnHUD == ExplicitDefaults.BullseyeOnHUD;
         }
 
         [JsonIgnore]
@@ -118,6 +136,12 @@ namespace JAFDTC.Models.A10C.Misc
         public CoordSystems CoordSystemValue
         {
             get => (CoordSystems)int.Parse((string.IsNullOrEmpty(CoordSystem)) ? ExplicitDefaults.CoordSystem : CoordSystem);
+        }
+
+        [JsonIgnore]
+        public bool IsBullseyeOnHUDValue
+        {
+            get => bool.Parse((string.IsNullOrEmpty(BullseyeOnHUD)) ? ExplicitDefaults.BullseyeOnHUD : BullseyeOnHUD);
         }
 
         [JsonIgnore]
@@ -140,6 +164,7 @@ namespace JAFDTC.Models.A10C.Misc
         public MiscSystem(MiscSystem other)
         {
             CoordSystem = new(other.CoordSystem);
+            BullseyeOnHUD = new(other.BullseyeOnHUD);
             FlightPlan1Manual = new(other.FlightPlan1Manual);
          }
 
@@ -156,6 +181,7 @@ namespace JAFDTC.Models.A10C.Misc
         public void Reset()
         {
             CoordSystem = "";
+            BullseyeOnHUD = "";
             FlightPlan1Manual = "";
          }
     }

--- a/JAFDTC/Models/A10C/Misc/MiscSystem.cs
+++ b/JAFDTC/Models/A10C/Misc/MiscSystem.cs
@@ -46,7 +46,7 @@ namespace JAFDTC.Models.A10C.Misc
     {
         IAS = 0,
         TAS = 1,
-        GND = 2
+        GS = 2
     }
 
     // defines the aap steer pt knob options
@@ -173,7 +173,7 @@ namespace JAFDTC.Models.A10C.Misc
         public bool IsDefault
         {
             get => IsCoordSystemDefault && IsBullseyeOnHUDDefault && IsFlightPlan1ManualDefault
-                   && IsAapSteerPtDefault && IsAapPageDefault;
+                   && IsSpeedDisplayDefault && IsAapSteerPtDefault && IsAapPageDefault;
         }
 
         [JsonIgnore]

--- a/JAFDTC/Models/A10C/Misc/MiscSystem.cs
+++ b/JAFDTC/Models/A10C/Misc/MiscSystem.cs
@@ -31,7 +31,15 @@ namespace JAFDTC.Models.A10C.Misc
         LL = 0,
         MGRS = 1
     }
- 
+
+    // defines the flight plan auto options
+    //
+    public enum FlightPlanManualOptions
+    {
+        Auto = 0,
+        Manual = 1
+    }
+
     /// <summary>
     /// TODO: document
     /// </summary>
@@ -58,6 +66,17 @@ namespace JAFDTC.Models.A10C.Misc
             }
         }
 
+        private string _flightPlan1Manual;                              // integer [0, 1]
+        public string FlightPlan1Manual
+        {
+            get => _flightPlan1Manual;
+            set
+            {
+                string error = (string.IsNullOrEmpty(value) || IsIntegerFieldValid(value, 0, 1)) ? null : "Invalid format";
+                SetProperty(ref _flightPlan1Manual, value, error);
+            }
+        }
+
         // ---- following properties are synthesized
 
         // returns a MiscSystem with the fields populated with the actual default values (note that usually the value
@@ -67,7 +86,8 @@ namespace JAFDTC.Models.A10C.Misc
         //
         public readonly static MiscSystem ExplicitDefaults = new()
         {
-            CoordSystem = "0" // Lat/Long
+            CoordSystem = "0", // Lat/Long
+            FlightPlan1Manual = "0" // Auto
         };
 
         // returns true if the instance indicates a default setup (all fields are "") or the object is in explicit
@@ -76,13 +96,19 @@ namespace JAFDTC.Models.A10C.Misc
         [JsonIgnore]
         public bool IsDefault
         {
-            get => (IsCoordSystemDefault);
+            get => IsCoordSystemDefault && IsFlightPlan1ManualDefault;
         }
 
         [JsonIgnore]
         public bool IsCoordSystemDefault
         {
             get => string.IsNullOrEmpty(CoordSystem) || CoordSystem == ExplicitDefaults.CoordSystem;
+        }
+
+        [JsonIgnore]
+        public bool IsFlightPlan1ManualDefault
+        {
+            get => string.IsNullOrEmpty(FlightPlan1Manual) || FlightPlan1Manual == ExplicitDefaults.FlightPlan1Manual;
         }
 
 
@@ -92,6 +118,12 @@ namespace JAFDTC.Models.A10C.Misc
         public CoordSystems CoordSystemValue
         {
             get => (CoordSystems)int.Parse((string.IsNullOrEmpty(CoordSystem)) ? ExplicitDefaults.CoordSystem : CoordSystem);
+        }
+
+        [JsonIgnore]
+        public FlightPlanManualOptions FlightPlan1ManualValue
+        {
+            get => (FlightPlanManualOptions)int.Parse((string.IsNullOrEmpty(FlightPlan1Manual)) ? ExplicitDefaults.FlightPlan1Manual : FlightPlan1Manual);
         }
 
         // ------------------------------------------------------------------------------------------------------------
@@ -108,6 +140,7 @@ namespace JAFDTC.Models.A10C.Misc
         public MiscSystem(MiscSystem other)
         {
             CoordSystem = new(other.CoordSystem);
+            FlightPlan1Manual = new(other.FlightPlan1Manual);
          }
 
         public virtual object Clone() => new MiscSystem(this);
@@ -123,6 +156,7 @@ namespace JAFDTC.Models.A10C.Misc
         public void Reset()
         {
             CoordSystem = "";
+            FlightPlan1Manual = "";
          }
     }
 }

--- a/JAFDTC/Models/A10C/Misc/MiscSystem.cs
+++ b/JAFDTC/Models/A10C/Misc/MiscSystem.cs
@@ -40,6 +40,15 @@ namespace JAFDTC.Models.A10C.Misc
         Manual = 1
     }
 
+    // defines the flight plan auto options
+    //
+    public enum SpeedDisplayOptions
+    {
+        IAS = 0,
+        TAS = 1,
+        GND = 2
+    }
+
     /// <summary>
     /// TODO: document
     /// </summary>
@@ -88,6 +97,17 @@ namespace JAFDTC.Models.A10C.Misc
             }
         }
 
+        private string _speedDisplay;                              // integer [0, 1, 2]
+        public string SpeedDisplay
+        {
+            get => _speedDisplay;
+            set
+            {
+                string error = (string.IsNullOrEmpty(value) || IsIntegerFieldValid(value, 0, 2)) ? null : "Invalid format";
+                SetProperty(ref _speedDisplay, value, error);
+            }
+        }
+
         // ---- following properties are synthesized
 
         // returns a MiscSystem with the fields populated with the actual default values (note that usually the value
@@ -99,7 +119,8 @@ namespace JAFDTC.Models.A10C.Misc
         {
             CoordSystem = "0", // Lat/Long
             BullseyeOnHUD = false.ToString(),
-            FlightPlan1Manual = "0" // Auto
+            FlightPlan1Manual = "0", // Auto
+            SpeedDisplay = "0", // IAS
         };
 
         // returns true if the instance indicates a default setup (all fields are "") or the object is in explicit
@@ -129,6 +150,12 @@ namespace JAFDTC.Models.A10C.Misc
             get => string.IsNullOrEmpty(FlightPlan1Manual) || FlightPlan1Manual == ExplicitDefaults.FlightPlan1Manual;
         }
 
+        [JsonIgnore]
+        public bool IsSpeedDisplayDefault
+        {
+            get => string.IsNullOrEmpty(SpeedDisplay) || SpeedDisplay == ExplicitDefaults.SpeedDisplay;
+        }
+
 
         // ---- following accessors get the current value (default or non-default) for various properties
 
@@ -150,6 +177,12 @@ namespace JAFDTC.Models.A10C.Misc
             get => (FlightPlanManualOptions)int.Parse((string.IsNullOrEmpty(FlightPlan1Manual)) ? ExplicitDefaults.FlightPlan1Manual : FlightPlan1Manual);
         }
 
+        [JsonIgnore]
+        public SpeedDisplayOptions SpeedDisplayValue
+        {
+            get => (SpeedDisplayOptions)int.Parse((string.IsNullOrEmpty(SpeedDisplay)) ? ExplicitDefaults.SpeedDisplay : SpeedDisplay);
+        }
+
         // ------------------------------------------------------------------------------------------------------------
         //
         // construction
@@ -166,6 +199,7 @@ namespace JAFDTC.Models.A10C.Misc
             CoordSystem = new(other.CoordSystem);
             BullseyeOnHUD = new(other.BullseyeOnHUD);
             FlightPlan1Manual = new(other.FlightPlan1Manual);
+            SpeedDisplay = new(other.SpeedDisplay);
          }
 
         public virtual object Clone() => new MiscSystem(this);
@@ -183,6 +217,7 @@ namespace JAFDTC.Models.A10C.Misc
             CoordSystem = "";
             BullseyeOnHUD = "";
             FlightPlan1Manual = "";
+            SpeedDisplay = "";
          }
     }
 }

--- a/JAFDTC/Models/A10C/Misc/MiscSystem.cs
+++ b/JAFDTC/Models/A10C/Misc/MiscSystem.cs
@@ -1,0 +1,128 @@
+﻿// ********************************************************************************************************************
+//
+// MiscSystem.cs -- a-10c miscellaneous system
+//
+// Copyright(C) 2021-2023 the-paid-actor & others
+// Copyright(C) 2023 ilominar/raven
+// Copyright(C) 2024 fizzle
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
+// Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program.  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// ********************************************************************************************************************
+
+using JAFDTC.Utilities;
+using System.Text.Json.Serialization;
+
+namespace JAFDTC.Models.A10C.Misc
+{
+    // defines the coordinate system options
+    //
+    public enum CoordSystems
+    {
+        LL = 0,
+        MGRS = 1
+    }
+ 
+    /// <summary>
+    /// TODO: document
+    /// </summary>
+    public class MiscSystem : BindableObject, ISystem
+    {
+        public const string SystemTag = "JAFDTC:A10C:MISC";
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // properties
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        // ---- following properties post change and validation events
+
+        private string _coordSystem;                              // integer [0, 1]
+        public string CoordSystem
+        {
+            get => _coordSystem;
+            set
+            {
+                string error = (string.IsNullOrEmpty(value) || IsIntegerFieldValid(value, 0, 1)) ? null : "Invalid format";
+                SetProperty(ref _coordSystem, value, error);
+            }
+        }
+
+        // ---- following properties are synthesized
+
+        // returns a MiscSystem with the fields populated with the actual default values (note that usually the value
+        // "" implies default).
+        //
+        // defaults are as of DCS v2.9.0.47168.
+        //
+        public readonly static MiscSystem ExplicitDefaults = new()
+        {
+            CoordSystem = "0" // Lat/Long
+        };
+
+        // returns true if the instance indicates a default setup (all fields are "") or the object is in explicit
+        // form, false otherwise.
+        //
+        [JsonIgnore]
+        public bool IsDefault
+        {
+            get => (IsCoordSystemDefault);
+        }
+
+        [JsonIgnore]
+        public bool IsCoordSystemDefault
+        {
+            get => string.IsNullOrEmpty(CoordSystem) || CoordSystem == ExplicitDefaults.CoordSystem;
+        }
+
+
+        // ---- following accessors get the current value (default or non-default) for various properties
+
+        [JsonIgnore]
+        public CoordSystems CoordSystemValue
+        {
+            get => (CoordSystems)int.Parse((string.IsNullOrEmpty(CoordSystem)) ? ExplicitDefaults.CoordSystem : CoordSystem);
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // construction
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        public MiscSystem()
+        {
+            Reset();
+        }
+
+        public MiscSystem(MiscSystem other)
+        {
+            CoordSystem = new(other.CoordSystem);
+         }
+
+        public virtual object Clone() => new MiscSystem(this);
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // Methods
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        // reset the instance to defaults (by definition, field value of "" implies default).
+        //
+        public void Reset()
+        {
+            CoordSystem = "";
+         }
+    }
+}

--- a/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
@@ -149,10 +149,10 @@ namespace JAFDTC.Models.A10C.Upload
             AddActions(ufc, new() { "FN", "0" });
 
             // CDU
-            // TODO verify current setting?
-            AddActions(cdu, new() { "LSK_9R" }); // TAS
-            if (miscSystem.SpeedDisplayValue == SpeedDisplayOptions.GND)
-                AddActions(cdu, new() { "LSK_9R" });
+            AddWhileBlock("SpeedIsNot", new() { $"{miscSystem.SpeedDisplayValue}" }, delegate () 
+            { 
+                AddAction(cdu, "LSK_9R");
+            });
         }
 
         /// <summary>

--- a/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
@@ -50,10 +50,12 @@ namespace JAFDTC.Models.A10C.Upload
         public override void Build()
         {
             AirframeDevice cdu = _aircraft.GetDevice("CDU");
+            AirframeDevice ufc = _aircraft.GetDevice("UFC");
 
             if (!_cfg.Misc.IsDefault)
             {
                 BuildCoordSystem(cdu, _cfg.Misc);
+                BuildBullseyeOnHUD(cdu, ufc, _cfg.Misc);
                 BuildFlightPlan1Manual(cdu, _cfg.Misc);
             }
         }
@@ -91,6 +93,23 @@ namespace JAFDTC.Models.A10C.Upload
             // AddActions(rmfd, new() { "RMFD_01" });
             // AddWait(WAIT_BASE);
             // AddActions(rmfd, new() { "RMFD_07", "RMFD_01", "RMFD_03", });
+        }
+
+        /// <summary>
+        /// configure the bullseye on hud setting according to the non-default programming settings
+        /// </summary>
+        /// <param name="cdu"></param>
+        /// <param name="miscSystem"></param>
+        private void BuildBullseyeOnHUD(AirframeDevice cdu, AirframeDevice ufc, MiscSystem miscSystem)
+        {
+            if (miscSystem.IsBullseyeOnHUDDefault)
+                return;
+
+            // Navigate to WAYPT page with UFC
+            AddActions(ufc, new() { "FN", "SPC"});
+
+            // CDU
+            AddActions(cdu, new() { "CLR", "LSK_7R", "LSK_9L" }); // TODO verify current setting?
         }
 
         /// <summary>

--- a/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
@@ -110,10 +110,15 @@ namespace JAFDTC.Models.A10C.Upload
                 return;
 
             // Navigate to WAYPT page with UFC
-            AddActions(ufc, new() { "FN", "SPC"});
+            AddActions(ufc, new() { "FN", "SPC" });
 
-            // CDU
-            AddActions(cdu, new() { "CLR", "LSK_7R", "LSK_9L" }); // TODO verify current setting?
+            // Navigate to ANCHOR PT page on  CDU
+            AddActions(cdu, new() { "CLR", "LSK_7R" });
+            // Turn BULLS ON if not already
+            AddIfBlock("IsBullsNotOnHUD", null, delegate ()
+            {
+                AddActions(cdu, new() { "LSK_9L" });
+            });
         }
 
         /// <summary>

--- a/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
@@ -1,0 +1,95 @@
+﻿// ********************************************************************************************************************
+//
+// RadioBuilder.cs -- a-10c misc system builder
+//
+// Copyright(C) 2024 fizzle, JAFDTC contributors
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
+// Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program.  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// ********************************************************************************************************************
+
+using JAFDTC.Models.A10C.Misc;
+using JAFDTC.Models.DCS;
+using System.Text;
+
+namespace JAFDTC.Models.A10C.Upload
+{
+    /// <summary>
+    /// command builder for the radio system in the warthog. translates cmds setup in A10CConfiguration into
+    /// commands that drive the dcs clickable cockpit.
+    /// </summary>
+    internal class MiscBuilder : A10CBuilderBase, IBuilder
+    {
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // construction
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        public MiscBuilder(A10CConfiguration cfg, A10CDeviceManager dcsCmds, StringBuilder sb) : base(cfg, dcsCmds, sb) { }
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // build methods
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        /// <summary>
+        /// configure misc systems via the cdu and ffds according to the non-default programming settings (this function is
+        /// safe to call with a configuration with default settings: defaults are skipped as necessary).
+        /// </summary>
+        public override void Build()
+        {
+            AirframeDevice cdu = _aircraft.GetDevice("CDU");
+
+            if (!_cfg.Misc.IsDefault)
+            {
+                BuildCoordSystem(cdu, _cfg.Misc);
+            }
+        }
+
+        /// <summary>
+        /// configure the coordinate system according to the non-default programming settings
+        /// </summary>
+        /// <param name="cdu"></param>
+        /// <param name="miscSystem"></param>
+        private void BuildCoordSystem(AirframeDevice cdu, MiscSystem miscSystem)
+        {
+            if (miscSystem.IsCoordSystemDefault)
+                return;
+
+            // CDU
+            AddActions(cdu, new() { "WP", "LSK_3L" });
+            AddWait(WAIT_BASE);
+            AddIfBlock("IsCoordFmtLL", null, delegate ()
+            {
+                AddActions(cdu, new() { "LSK_9R" });
+            });
+
+            // TAD
+            // Leaving this as a reference for changing the coordinate system on the TAD
+            // when we add it as its own system later.
+            // AddActions(lmfd, new() { "LMFD_15", "LMFD_09" });
+
+            // TGP
+            // Leaving this as a reference for changing the coordinate system on the TGP
+            // when we add it as its own system later.
+            // AddActions(rmfd, new() { "RMFD_15" });
+            // AddWait(WAIT_BASE);
+            // AddActions(rmfd, new() { "RMFD_02" });
+            // AddWait(WAIT_BASE * 5); // Wait for TGP to go active.
+            // AddActions(rmfd, new() { "RMFD_01" });
+            // AddWait(WAIT_BASE);
+            // AddActions(rmfd, new() { "RMFD_07", "RMFD_01", "RMFD_03", });
+        }
+    }
+}

--- a/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
@@ -132,7 +132,11 @@ namespace JAFDTC.Models.A10C.Upload
                 return;
 
             // CDU
-            AddActions(cdu, new() { "FPM", "LSK_3L" }); // TODO verify current setting?
+            AddAction(cdu, "FPM");
+            AddIfBlock("IsFlightPlanNotManual", null, delegate ()
+            {
+                AddAction(cdu, "LSK_3L");
+            });
         }
 
         /// <summary>

--- a/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
@@ -54,6 +54,7 @@ namespace JAFDTC.Models.A10C.Upload
             if (!_cfg.Misc.IsDefault)
             {
                 BuildCoordSystem(cdu, _cfg.Misc);
+                BuildFlightPlan1Manual(cdu, _cfg.Misc);
             }
         }
 
@@ -90,6 +91,20 @@ namespace JAFDTC.Models.A10C.Upload
             // AddActions(rmfd, new() { "RMFD_01" });
             // AddWait(WAIT_BASE);
             // AddActions(rmfd, new() { "RMFD_07", "RMFD_01", "RMFD_03", });
+        }
+
+        /// <summary>
+        /// configure the first flight plan's manual/auto setting according to the non-default programming settings
+        /// </summary>
+        /// <param name="cdu"></param>
+        /// <param name="miscSystem"></param>
+        private void BuildFlightPlan1Manual(AirframeDevice cdu, MiscSystem miscSystem)
+        {
+            if (miscSystem.IsFlightPlan1ManualDefault)
+                return;
+
+            // CDU
+            AddActions(cdu, new() { "FPM", "LSK_3L" }); // TODO verify current setting?
         }
     }
 }

--- a/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
@@ -51,6 +51,7 @@ namespace JAFDTC.Models.A10C.Upload
         {
             AirframeDevice cdu = _aircraft.GetDevice("CDU");
             AirframeDevice ufc = _aircraft.GetDevice("UFC");
+            AirframeDevice aap = _aircraft.GetDevice("AAP");
 
             if (!_cfg.Misc.IsDefault)
             {
@@ -58,6 +59,8 @@ namespace JAFDTC.Models.A10C.Upload
                 BuildBullseyeOnHUD(cdu, ufc, _cfg.Misc);
                 BuildFlightPlan1Manual(cdu, _cfg.Misc);
                 BuildSpeedDisplay(cdu, ufc, _cfg.Misc);
+                BuildAapSteerPt(aap, _cfg.Misc);
+                BuildAapPage(aap, _cfg.Misc);
             }
         }
 
@@ -145,6 +148,51 @@ namespace JAFDTC.Models.A10C.Upload
             AddActions(cdu, new() { "LSK_9R" }); // TAS
             if (miscSystem.SpeedDisplayValue == SpeedDisplayOptions.GND)
                 AddActions(cdu, new() { "LSK_9R" });
+        }
+
+        /// <summary>
+        /// configure the AAP Steerpoint knob setting according to the non-default programming settings
+        /// </summary>
+        /// <param name="cdu"></param>
+        /// <param name="miscSystem"></param>
+        private void BuildAapSteerPt(AirframeDevice aap, MiscSystem miscSystem)
+        {
+            if (miscSystem.IsAapSteerPtDefault)
+                return; // Flt Plan
+
+            switch (miscSystem.AapSteerPtValue)
+            {
+                case AapSteerPtOptions.Mark:
+                    AddActions(aap, new() { "STEER_MARK" });
+                    break;
+                case AapSteerPtOptions.Mission:
+                    AddActions(aap, new() { "STEER_MISSION" });
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// configure the AAP Page knob setting according to the non-default programming settings
+        /// </summary>
+        /// <param name="cdu"></param>
+        /// <param name="miscSystem"></param>
+        private void BuildAapPage(AirframeDevice aap, MiscSystem miscSystem)
+        {
+            if (miscSystem.IsAapPageDefault)
+                return; // Other
+
+            switch (miscSystem.AapPageValue)
+            {
+                case AapPageOptions.Position:
+                    AddActions(aap, new() { "PAGE_POSITION" });
+                    break;
+                case AapPageOptions.Steer:
+                    AddActions(aap, new() { "PAGE_STEER" });
+                    break;
+                case AapPageOptions.Waypt:
+                    AddActions(aap, new() { "PAGE_WAYPT" });
+                    break;
+            }
         }
     }
 }

--- a/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
@@ -79,7 +79,7 @@ namespace JAFDTC.Models.A10C.Upload
             AddWait(WAIT_BASE);
             AddIfBlock("IsCoordFmtLL", null, delegate ()
             {
-                AddActions(cdu, new() { "LSK_9R" });
+                AddAction(cdu, "LSK_9R");
             });
 
             // TAD
@@ -117,7 +117,7 @@ namespace JAFDTC.Models.A10C.Upload
             // Turn BULLS ON if not already
             AddIfBlock("IsBullsNotOnHUD", null, delegate ()
             {
-                AddActions(cdu, new() { "LSK_9L" });
+                AddAction(cdu, "LSK_9L");
             });
         }
 
@@ -168,10 +168,10 @@ namespace JAFDTC.Models.A10C.Upload
             switch (miscSystem.AapSteerPtValue)
             {
                 case AapSteerPtOptions.Mark:
-                    AddActions(aap, new() { "STEER_MARK" });
+                    AddAction(aap, "STEER_MARK");
                     break;
                 case AapSteerPtOptions.Mission:
-                    AddActions(aap, new() { "STEER_MISSION" });
+                    AddAction(aap, "STEER_MISSION");
                     break;
             }
         }
@@ -189,13 +189,13 @@ namespace JAFDTC.Models.A10C.Upload
             switch (miscSystem.AapPageValue)
             {
                 case AapPageOptions.Position:
-                    AddActions(aap, new() { "PAGE_POSITION" });
+                    AddAction(aap, "PAGE_POSITION");
                     break;
                 case AapPageOptions.Steer:
-                    AddActions(aap, new() { "PAGE_STEER" });
+                    AddAction(aap, "PAGE_STEER");
                     break;
                 case AapPageOptions.Waypt:
-                    AddActions(aap, new() { "PAGE_WAYPT" });
+                    AddAction(aap, "PAGE_WAYPT");
                     break;
             }
         }

--- a/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
@@ -57,6 +57,7 @@ namespace JAFDTC.Models.A10C.Upload
                 BuildCoordSystem(cdu, _cfg.Misc);
                 BuildBullseyeOnHUD(cdu, ufc, _cfg.Misc);
                 BuildFlightPlan1Manual(cdu, _cfg.Misc);
+                BuildSpeedDisplay(cdu, ufc, _cfg.Misc);
             }
         }
 
@@ -124,6 +125,26 @@ namespace JAFDTC.Models.A10C.Upload
 
             // CDU
             AddActions(cdu, new() { "FPM", "LSK_3L" }); // TODO verify current setting?
+        }
+
+        /// <summary>
+        /// configure the CDU Steerpoint page speed display setting according to the non-default programming settings
+        /// </summary>
+        /// <param name="cdu"></param>
+        /// <param name="miscSystem"></param>
+        private void BuildSpeedDisplay(AirframeDevice cdu, AirframeDevice ufc, MiscSystem miscSystem)
+        {
+            if (miscSystem.IsSpeedDisplayDefault)
+                return; // IAS
+
+            // Navigate to STEER page with UFC
+            AddActions(ufc, new() { "FN", "0" });
+
+            // CDU
+            // TODO verify current setting?
+            AddActions(cdu, new() { "LSK_9R" }); // TAS
+            if (miscSystem.SpeedDisplayValue == SpeedDisplayOptions.GND)
+                AddActions(cdu, new() { "LSK_9R" });
         }
     }
 }

--- a/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
@@ -51,7 +51,8 @@ namespace JAFDTC.Models.A10C.Upload
         {
             AirframeDevice cdu = _aircraft.GetDevice("CDU");
             AirframeDevice ufc = _aircraft.GetDevice("UFC");
-            AirframeDevice aap = _aircraft.GetDevice("AAP");
+            AirframeDevice aap = _aircraft.GetDevice("AAP"); // "auxiliary avionics panel"
+            AirframeDevice ap  = _aircraft.GetDevice("AUTOPILOT");
 
             if (!_cfg.Misc.IsDefault)
             {
@@ -61,6 +62,7 @@ namespace JAFDTC.Models.A10C.Upload
                 BuildSpeedDisplay(cdu, ufc, _cfg.Misc);
                 BuildAapSteerPt(aap, _cfg.Misc);
                 BuildAapPage(aap, _cfg.Misc);
+                BuildAutopilot(ap, _cfg.Misc);
             }
         }
 
@@ -202,6 +204,15 @@ namespace JAFDTC.Models.A10C.Upload
                     AddAction(aap, "PAGE_WAYPT");
                     break;
             }
+        }
+
+        private void BuildAutopilot(AirframeDevice ap, MiscSystem miscSystem)
+        {
+            if (miscSystem.IsAutopilotModeDefault)
+                return; // Alt/Hdg
+
+            int setValue = (int)miscSystem.AutopilotModeValue;
+            AddDynamicAction(ap, "AP_MODE", setValue, setValue);
         }
     }
 }

--- a/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
@@ -58,6 +58,9 @@ namespace JAFDTC.Models.A10C.Upload
 
             if (wypts.Count > 0)
             {
+                // TODO: set STEER_PT to MISSION
+                // TODO: set PAGE to OTHER
+
                 AddActions(cdu, new() { "WP", "LSK_3L" });
                 AddWait(WAIT_BASE);
 

--- a/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
@@ -73,11 +73,15 @@ namespace JAFDTC.Models.A10C.Upload
                 AddActions(cdu, new() { "CLR", "CLR" });
                 AddWait(WAIT_BASE);
 
+                bool resetUTM = false;
                 AddIfBlock("IsCoordFmtNotLL", null, delegate ()
                 {
+                    resetUTM = true;
                     AddActions(cdu, new() { "LSK_9R" });
                 });
                 BuildWaypoints(cdu, wypts);
+                if (resetUTM)
+                    AddActions(cdu, new() { "LSK_9R" });
             }
         }
 

--- a/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
@@ -58,9 +58,6 @@ namespace JAFDTC.Models.A10C.Upload
 
             if (wypts.Count > 0)
             {
-                // TODO: set STEER_PT to MISSION
-                // TODO: set PAGE to OTHER
-
                 AddActions(cdu, new() { "WP", "LSK_3L" });
                 AddWait(WAIT_BASE);
 

--- a/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
@@ -73,15 +73,16 @@ namespace JAFDTC.Models.A10C.Upload
                 AddActions(cdu, new() { "CLR", "CLR" });
                 AddWait(WAIT_BASE);
 
-                bool resetUTM = false;
+                AddIfBlock("IsCoordFmtLL", null, delegate ()
+                {
+                    BuildWaypoints(cdu, wypts);
+                });
                 AddIfBlock("IsCoordFmtNotLL", null, delegate ()
                 {
-                    resetUTM = true;
-                    AddActions(cdu, new() { "LSK_9R" });
+                    AddActions(cdu, new() { "LSK_9R" }); // Change to LL
+                    BuildWaypoints(cdu, wypts);
+                    AddActions(cdu, new() { "LSK_9R" }); // Go back to UTM
                 });
-                BuildWaypoints(cdu, wypts);
-                if (resetUTM)
-                    AddActions(cdu, new() { "LSK_9R" });
             }
         }
 

--- a/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
@@ -55,11 +55,17 @@ namespace JAFDTC.Models.A10C.Upload
         {
             ObservableCollection<WaypointInfo> wypts = _cfg.WYPT.Points;
             AirframeDevice cdu = _aircraft.GetDevice("CDU");
+            AirframeDevice aap = _aircraft.GetDevice("AAP");
 
             if (wypts.Count > 0)
             {
-                // TODO: set STEER_PT to MISSION
-                // TODO: set PAGE to OTHER
+                // STEER PT Knob to MISSION
+                AddActions(aap, new() { "STEER_MISSION" });
+                AddWait(WAIT_BASE);
+
+                // CDU Page Knob to OTHER
+                AddActions(aap, new() { "PAGE_OTHER" });
+                AddWait(WAIT_BASE);
 
                 AddActions(cdu, new() { "WP", "LSK_3L" });
                 AddWait(WAIT_BASE);

--- a/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
@@ -109,9 +109,13 @@ namespace JAFDTC.Models.A10C.Upload
                     
                     BuildWaypointCoords(cdu, wypt);
 
-                    AddActions(cdu, ActionsForString(Math.Max(int.Parse(wypt.Alt), 0).ToString()), new() { "LSK_5L" });
-                    AddWait(WAIT_BASE);
-                    AddActions(cdu, new() { "CLR", "CLR" });
+                    // If no altitude was entered, leave it at the A-10's ground level altitude.
+                    if (!string.IsNullOrEmpty(wypt.Alt))
+                    {
+                        AddActions(cdu, ActionsForString(Math.Max(int.Parse(wypt.Alt), 0).ToString()), new() { "LSK_5L" });
+                        AddWait(WAIT_BASE);
+                        AddActions(cdu, new() { "CLR", "CLR" });
+                    }
                 }
             }
         }

--- a/JAFDTC/Models/A10C/WYPT/WaypointInfo.cs
+++ b/JAFDTC/Models/A10C/WYPT/WaypointInfo.cs
@@ -75,7 +75,34 @@ namespace JAFDTC.Models.A10C.WYPT
             }
         }
 
+        public override string Alt
+        {
+            get => _alt;
+            set
+            {
+                string error = "Invalid altitude format";
+                if (IsIntegerFieldValid(value, -80000, 80000))
+                {
+                    value = FixupIntegerField(value);
+                    error = null;
+                }
+                SetProperty(ref _alt, value, error);
+            }
+        }
+
         // TODO: could add support for TOS
+
+        // ---- public properties, computed
+
+        [JsonIgnore]
+        public override bool IsValid => IsIntegerFieldValid(_alt, -80000, 80000, true) &&
+                                        IsDecimalFieldValid(Lat, -90.0, 90.0, false) &&
+                                        IsDecimalFieldValid(Lon, -180.0, 180.0, false);
+
+        [JsonIgnore]
+        public override string Location => ((string.IsNullOrEmpty(Lat)) ? "Unknown" : Coord.RemoveLLDegZeroFill(LatUI)) + ", " +
+                                          ((string.IsNullOrEmpty(Lon)) ? "Unknown" : Coord.RemoveLLDegZeroFill(LonUI)) + " / " +
+                                          ((string.IsNullOrEmpty(Alt)) ? "Ground" : Alt + "’");
 
         // ------------------------------------------------------------------------------------------------------------
         //

--- a/JAFDTC/UI/A10C/A10CConfigurationEditor.cs
+++ b/JAFDTC/UI/A10C/A10CConfigurationEditor.cs
@@ -17,10 +17,11 @@
 //
 // ********************************************************************************************************************
 
-using JAFDTC.Models.A10C;
-using JAFDTC.Models.A10C.WYPT;
-using JAFDTC.Models.A10C.Radio;
 using JAFDTC.Models;
+using JAFDTC.Models.A10C;
+using JAFDTC.Models.A10C.Misc;
+using JAFDTC.Models.A10C.Radio;
+using JAFDTC.Models.A10C.WYPT;
 using JAFDTC.UI.App;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -28,7 +29,7 @@ using JAFDTC.UI.F16C;
 
 namespace JAFDTC.UI.A10C
 {
-    // defines the glyphs to use for each system editor page in the viper configuration.
+    // defines the glyphs to use for each system editor page in the hawg configuration.
     //
     public class Glyphs
     {
@@ -38,7 +39,7 @@ namespace JAFDTC.UI.A10C
     }
 
     /// <summary>
-    /// TODO: docuemnt
+    /// TODO: document
     /// </summary>
     public class A10CConfigurationEditor : ConfigurationEditor
     {
@@ -47,14 +48,17 @@ namespace JAFDTC.UI.A10C
         public override ObservableCollection<ConfigEditorPageInfo> ConfigEditorPageInfo()
             => new()
             {
+                // This is the order they appear in the UI. Resist the temptation to alphabetize.
                 A10CEditWaypointListHelper.PageInfo,
-                A10CEditRadioPageHelper.PageInfo
+                A10CEditRadioPageHelper.PageInfo,
+                A10CEditMiscPage.PageInfo
             };
 
         public override ISystem SystemForConfig(IConfiguration config, string tag)
         {
             ISystem system = tag switch
             {
+                MiscSystem.SystemTag => ((A10CConfiguration)config).Misc,
                 RadioSystem.SystemTag => ((A10CConfiguration)config).Radio,
                 WYPTSystem.SystemTag => ((A10CConfiguration)config).WYPT,
                 _ => null,

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
@@ -112,7 +112,7 @@
                     <!-- Tag is enum TODO -->
                     <TextBlock Text="IAS" Tag="0"/>
                     <TextBlock Text="TAS" Tag="1"/>
-                    <TextBlock Text="GND" Tag="2"/>
+                    <TextBlock Text="GS" Tag="2"/>
                 </ComboBox.Items>
             </ComboBox>
 

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
@@ -33,6 +33,7 @@
                 <RowDefinition/>
                 <RowDefinition/>
                 <RowDefinition/>
+                <RowDefinition/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
@@ -49,7 +50,7 @@
                 HorizontalTextAlignment="Right">
                 Coordinate System
             </TextBlock>
-            <ComboBox Grid.Row="1" Grid.Column="1" Margin="12,12,0,0" Width="200"
+            <ComboBox Grid.Row="1" Grid.Column="1" Margin="12,12,0,0"
                 x:Name="uiComboCoordSystem"
                 VerticalAlignment="Center"
                 ToolTipService.ToolTip="Coordinate System Selection"
@@ -80,7 +81,7 @@
                 HorizontalTextAlignment="Right">
                 FPM Flight Plan 01
             </TextBlock>
-            <ComboBox Grid.Row="3" Grid.Column="1" Margin="12,12,0,0" Width="200"
+            <ComboBox Grid.Row="3" Grid.Column="1" Margin="12,12,0,0"
                 x:Name="uiComboFlightPlan1Manual"
                 VerticalAlignment="Center"
                 ToolTipService.ToolTip="Flight Plan 01 Auto/Manual"
@@ -89,6 +90,25 @@
                     <!-- Tag is enum TODO -->
                     <TextBlock Text="Auto" Tag="0"/>
                     <TextBlock Text="Manual" Tag="1"/>
+                </ComboBox.Items>
+            </ComboBox>
+
+            <!-- STEER Page Speed Display setup -->
+            <TextBlock Grid.Row="4" Grid.Column="0" Margin="12,12,0,0"
+                Style="{StaticResource EditorParamStaticTextBlockStyle}"
+                HorizontalTextAlignment="Right">
+                STEER Page Speed Display
+            </TextBlock>
+            <ComboBox Grid.Row="4" Grid.Column="1" Margin="12,12,0,0"
+                x:Name="uiComboSpeedDisplay"
+                VerticalAlignment="Center"
+                ToolTipService.ToolTip="Speed Displayed on the CDU STEER Page"
+                SelectionChanged="ComboSpeedDisplay_SelectionChanged">
+                <ComboBox.Items>
+                    <!-- Tag is enum TODO -->
+                    <TextBlock Text="IAS" Tag="0"/>
+                    <TextBlock Text="TAS" Tag="1"/>
+                    <TextBlock Text="GND" Tag="2"/>
                 </ComboBox.Items>
             </ComboBox>
         </Grid>

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
@@ -37,6 +37,8 @@
                 <RowDefinition/>
                 <RowDefinition/>
                 <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
@@ -147,7 +149,7 @@
                 PAGE
             </TextBlock>
             <ComboBox Grid.Row="7" Grid.Column="1" Margin="12,12,0,0"
-                x:Name="uiComboPage"
+                x:Name="uiComboAapPage"
                 VerticalAlignment="Center"
                 ToolTipService.ToolTip="CDU PAGE Selection"
                 SelectionChanged="ComboPage_SelectionChanged">
@@ -157,6 +159,30 @@
                     <TextBlock Text="Position" Tag="1"/>
                     <TextBlock Text="Steer" Tag="2"/>
                     <TextBlock Text="Waypt" Tag="3"/>
+                </ComboBox.Items>
+            </ComboBox>
+
+            <TextBlock Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,12,0,0"
+                       Style="{StaticResource EditorTitleTextBlockStyle}">
+                Autopilot Configuration:
+            </TextBlock>
+
+            <!-- Autopilot Mode Switch setup -->
+            <TextBlock Grid.Row="9" Grid.Column="0" Margin="12,12,0,0"
+                Style="{StaticResource EditorParamStaticTextBlockStyle}"
+                HorizontalTextAlignment="Right">
+                Mode
+            </TextBlock>
+            <ComboBox Grid.Row="9" Grid.Column="1" Margin="12,12,0,0"
+                x:Name="uiComboAutopilotMode"
+                VerticalAlignment="Center"
+                ToolTipService.ToolTip="Autopilot Mode Selection"
+                SelectionChanged="ComboAutopilotMode_SelectionChanged">
+                <ComboBox.Items>
+                    <!-- Tag is enum TODO -->
+                    <TextBlock Text="PATH" Tag="1"/>
+                    <TextBlock Text="ALT/HDG" Tag="0"/>
+                    <TextBlock Text="ALT" Tag="-1"/>
                 </ComboBox.Items>
             </ComboBox>
         </Grid>

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
@@ -32,6 +32,7 @@
                 <RowDefinition/>
                 <RowDefinition/>
                 <RowDefinition/>
+                <RowDefinition/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
@@ -41,7 +42,7 @@
             <!-- Coordinate System setup -->
             <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
                        Style="{StaticResource EditorTitleTextBlockStyle}">
-                CDU Navigation Configuration:
+                CDU Misc Configuration:
             </TextBlock>
             <TextBlock Grid.Row="1" Grid.Column="0" Margin="12,12,0,0"
                 Style="{StaticResource EditorParamStaticTextBlockStyle}"
@@ -60,13 +61,26 @@
                 </ComboBox.Items>
             </ComboBox>
 
-            <!-- Flight Plan 1 Auto/Manual setup -->
+            <!-- Bullseye on HUD setup -->
             <TextBlock Grid.Row="2" Grid.Column="0" Margin="12,12,0,0"
+                Style="{StaticResource EditorParamStaticTextBlockStyle}"
+                HorizontalTextAlignment="Right">
+                Bullseye on HUD
+            </TextBlock>
+            <CheckBox Grid.Row="2" Grid.Column="1" Margin="12,12,0,0"
+                x:Name="uiCkboxBullsOnHUD"
+                VerticalAlignment="Center"
+                ToolTipService.ToolTip="Display Bullseye Position on HUD"
+                Click="uiCkboxBullsOnHUD_Click">
+            </CheckBox>
+
+            <!-- Flight Plan 1 Auto/Manual setup -->
+            <TextBlock Grid.Row="3" Grid.Column="0" Margin="12,12,0,0"
                 Style="{StaticResource EditorParamStaticTextBlockStyle}"
                 HorizontalTextAlignment="Right">
                 FPM Flight Plan 01
             </TextBlock>
-            <ComboBox Grid.Row="2" Grid.Column="1" Margin="12,12,0,0" Width="200"
+            <ComboBox Grid.Row="3" Grid.Column="1" Margin="12,12,0,0" Width="200"
                 x:Name="uiComboFlightPlan1Manual"
                 VerticalAlignment="Center"
                 ToolTipService.ToolTip="Flight Plan 01 Auto/Manual"

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
@@ -17,46 +17,48 @@
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition/>
+            <ColumnDefinition/>
         </Grid.ColumnDefinitions>
 
-        <Grid Grid.Row="0" Grid.Column="0" Margin="12,0,12,0"
+        <!--
+        ===============================================================================================================
+        left column 
+        ===============================================================================================================
+        -->
+        <Grid Grid.Row="0" Grid.Column="0" Margin="16,8,12,8"
             VerticalAlignment="Top"
             HorizontalAlignment="Center">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
+                <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition/>
             </Grid.ColumnDefinitions>
 
             <!-- Coordinate System setup -->
-            <TextBlock Grid.Row="0" Grid.Column="0" Margin="12,12,0,0"
+            <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
+                       Style="{StaticResource EditorTitleTextBlockStyle}">
+                CDU Navigation Configuration:
+            </TextBlock>
+            <TextBlock Grid.Row="1" Grid.Column="0" Margin="12,12,0,0"
                 Style="{StaticResource EditorParamStaticTextBlockStyle}"
                 HorizontalTextAlignment="Right">
                 Coordinate System
             </TextBlock>
-            <StackPanel Grid.Row="0" Grid.Column="1" Margin="12,20,0,0" Orientation="Horizontal">
-                <ComboBox Width="200"
-                    x:Name="uiComboCoordSystem"
-                    VerticalAlignment="Center"
-                    ToolTipService.ToolTip="Coordinate System Selection"
-                    SelectionChanged="ComboCoordSystem_SelectionChanged">
-                    <ComboBox.Items>
-                        <!-- Tag is enum TODO -->
-                        <TextBlock Text="Latitude/Longitude" Tag="0"/>
-                        <TextBlock Text="MGRS" Tag="1"/>
-                    </ComboBox.Items>
-                </ComboBox>
-            </StackPanel>
-            <TextBlock Grid.Row="2" Grid.Column="0" Margin="0,0,0,0"
-                FontSize="12"
-                FontStyle="Italic"
-                Foreground="{StaticResource TextFillColorTertiary}"
-                HorizontalTextAlignment="Right">
-                Changes TAD, CDU, and TGP
-            </TextBlock>
+            <ComboBox Grid.Row="1" Grid.Column="1" Margin="12,12,0,0" Width="200"
+                x:Name="uiComboCoordSystem"
+                VerticalAlignment="Center"
+                ToolTipService.ToolTip="Coordinate System Selection"
+                SelectionChanged="ComboCoordSystem_SelectionChanged">
+                <ComboBox.Items>
+                    <!-- Tag is enum TODO -->
+                    <TextBlock Text="Latitude/Longitude" Tag="0"/>
+                    <TextBlock Text="MGRS" Tag="1"/>
+                </ComboBox.Items>
+            </ComboBox>
         </Grid>
 
         <!--

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="JAFDTC.UI.A10C.A10CEditMiscPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:JAFDTC.Models.A10C"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+
+        <Grid Grid.Row="0" Grid.Column="0" Margin="12,0,12,0"
+            VerticalAlignment="Top"
+            HorizontalAlignment="Center">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Coordinate System setup -->
+            <TextBlock Grid.Row="0" Grid.Column="0" Margin="12,12,0,0"
+                Style="{StaticResource EditorParamStaticTextBlockStyle}"
+                HorizontalTextAlignment="Right">
+                Coordinate System
+            </TextBlock>
+            <StackPanel Grid.Row="0" Grid.Column="1" Margin="12,20,0,0" Orientation="Horizontal">
+                <ComboBox Width="200"
+                    x:Name="uiComboCoordSystem"
+                    VerticalAlignment="Center"
+                    ToolTipService.ToolTip="Coordinate System Selection"
+                    SelectionChanged="ComboCoordSystem_SelectionChanged">
+                    <ComboBox.Items>
+                        <!-- Tag is enum TODO -->
+                        <TextBlock Text="Latitude/Longitude" Tag="0"/>
+                        <TextBlock Text="MGRS" Tag="1"/>
+                    </ComboBox.Items>
+                </ComboBox>
+            </StackPanel>
+            <TextBlock Grid.Row="2" Grid.Column="0" Margin="0,0,0,0"
+                FontSize="12"
+                FontStyle="Italic"
+                Foreground="{StaticResource TextFillColorTertiary}"
+                HorizontalTextAlignment="Right">
+                Changes TAD, CDU, and TGP
+            </TextBlock>
+        </Grid>
+
+        <!--
+        ===============================================================================================================
+        link / reset
+        ===============================================================================================================
+        -->
+        <Grid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="12,12,12,12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0"
+                        VerticalAlignment="Bottom"
+                        Orientation="Horizontal">
+                <Button Width="140"
+                        x:Name="uiPageBtnLink"
+                        Click="PageBtnLink_Click"
+                        ToolTipService.ToolTip="Link or unlink this system to/from another configuration">
+                    <StackPanel Orientation="Horizontal">
+                        <FontIcon Margin="0,0,6,0"
+                                  FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE71B;"/>
+                        <TextBlock VerticalAlignment="center"
+                                   x:Name="uiPageBtnTxtLink">
+                            FIXUP
+                        </TextBlock>
+                    </StackPanel>
+                </Button>
+                <TextBlock Margin="12,0,24,0"
+                           x:Name="uiPageTxtLink"
+                           VerticalAlignment="center">
+                    FIXUP
+                </TextBlock>
+            </StackPanel>
+
+            <StackPanel Grid.Column="1"
+                        VerticalAlignment="Bottom"
+                        Orientation="Horizontal">
+                <Button x:Name="uiPageBtnReset"
+                        Click="PageBtnReset_Click"
+                        ToolTipService.ToolTip="Reset the configuration of this system to its defaults">
+                    <StackPanel Orientation="Horizontal">
+                        <FontIcon Margin="0,0,6,0"
+                                  FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE894;"/>
+                        <TextBlock VerticalAlignment="center">Reset Page to Defaults</TextBlock>
+                    </StackPanel>
+                </Button>
+            </StackPanel>
+        </Grid>
+        
+    </Grid>
+</Page>

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
@@ -59,6 +59,24 @@
                     <TextBlock Text="MGRS" Tag="1"/>
                 </ComboBox.Items>
             </ComboBox>
+
+            <!-- Coordinate System setup -->
+            <TextBlock Grid.Row="2" Grid.Column="0" Margin="12,12,0,0"
+                Style="{StaticResource EditorParamStaticTextBlockStyle}"
+                HorizontalTextAlignment="Right">
+                FPM Flight Plan 01
+            </TextBlock>
+            <ComboBox Grid.Row="2" Grid.Column="1" Margin="12,12,0,0" Width="200"
+                x:Name="uiComboFlightPlan1Manual"
+                VerticalAlignment="Center"
+                ToolTipService.ToolTip="Flight Plan 01 Auto/Manual"
+                SelectionChanged="ComboFPM01_SelectionChanged">
+                <ComboBox.Items>
+                    <!-- Tag is enum TODO -->
+                    <TextBlock Text="Auto" Tag="0"/>
+                    <TextBlock Text="Manual" Tag="1"/>
+                </ComboBox.Items>
+            </ComboBox>
         </Grid>
 
         <!--

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
@@ -34,17 +34,21 @@
                 <RowDefinition/>
                 <RowDefinition/>
                 <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition/>
             </Grid.ColumnDefinitions>
 
-            <!-- Coordinate System setup -->
             <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
                        Style="{StaticResource EditorTitleTextBlockStyle}">
                 CDU Misc Configuration:
             </TextBlock>
+
+            <!-- Coordinate System setup -->
             <TextBlock Grid.Row="1" Grid.Column="0" Margin="12,12,0,0"
                 Style="{StaticResource EditorParamStaticTextBlockStyle}"
                 HorizontalTextAlignment="Right">
@@ -57,7 +61,7 @@
                 SelectionChanged="ComboCoordSystem_SelectionChanged">
                 <ComboBox.Items>
                     <!-- Tag is enum TODO -->
-                    <TextBlock Text="Latitude/Longitude" Tag="0"/>
+                    <TextBlock Text="Lat/Long" Tag="0"/>
                     <TextBlock Text="MGRS" Tag="1"/>
                 </ComboBox.Items>
             </ComboBox>
@@ -109,6 +113,50 @@
                     <TextBlock Text="IAS" Tag="0"/>
                     <TextBlock Text="TAS" Tag="1"/>
                     <TextBlock Text="GND" Tag="2"/>
+                </ComboBox.Items>
+            </ComboBox>
+
+            <TextBlock Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,12,0,0"
+                       Style="{StaticResource EditorTitleTextBlockStyle}">
+                AAP Configuration:
+            </TextBlock>
+
+            <!-- STEER PT Knob setup -->
+            <TextBlock Grid.Row="6" Grid.Column="0" Margin="12,12,0,0"
+                Style="{StaticResource EditorParamStaticTextBlockStyle}"
+                HorizontalTextAlignment="Right">
+                STEER PT
+            </TextBlock>
+            <ComboBox Grid.Row="6" Grid.Column="1" Margin="12,12,0,0"
+                x:Name="uiComboSteerPt"
+                VerticalAlignment="Center"
+                ToolTipService.ToolTip="STEER PT Selection"
+                SelectionChanged="ComboSteerPt_SelectionChanged">
+                <ComboBox.Items>
+                    <!-- Tag is enum TODO -->
+                    <TextBlock Text="Flt Plan" Tag="0"/>
+                    <TextBlock Text="Mark" Tag="1"/>
+                    <TextBlock Text="Mission" Tag="2"/>
+                </ComboBox.Items>
+            </ComboBox>
+
+            <!-- CDU PAGE Knob setup -->
+            <TextBlock Grid.Row="7" Grid.Column="0" Margin="12,12,0,0"
+                Style="{StaticResource EditorParamStaticTextBlockStyle}"
+                HorizontalTextAlignment="Right">
+                PAGE
+            </TextBlock>
+            <ComboBox Grid.Row="7" Grid.Column="1" Margin="12,12,0,0"
+                x:Name="uiComboPage"
+                VerticalAlignment="Center"
+                ToolTipService.ToolTip="CDU PAGE Selection"
+                SelectionChanged="ComboPage_SelectionChanged">
+                <ComboBox.Items>
+                    <!-- Tag is enum TODO -->
+                    <TextBlock Text="Other" Tag="0"/>
+                    <TextBlock Text="Position" Tag="1"/>
+                    <TextBlock Text="Steer" Tag="2"/>
+                    <TextBlock Text="Waypt" Tag="3"/>
                 </ComboBox.Items>
             </ComboBox>
         </Grid>

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
@@ -60,7 +60,7 @@
                 </ComboBox.Items>
             </ComboBox>
 
-            <!-- Coordinate System setup -->
+            <!-- Flight Plan 1 Auto/Manual setup -->
             <TextBlock Grid.Row="2" Grid.Column="0" Margin="12,12,0,0"
                 Style="{StaticResource EditorParamStaticTextBlockStyle}"
                 HorizontalTextAlignment="Right">
@@ -70,7 +70,7 @@
                 x:Name="uiComboFlightPlan1Manual"
                 VerticalAlignment="Center"
                 ToolTipService.ToolTip="Flight Plan 01 Auto/Manual"
-                SelectionChanged="ComboFPM01_SelectionChanged">
+                SelectionChanged="ComboFlightPlan1Manual_SelectionChanged">
                 <ComboBox.Items>
                     <!-- Tag is enum TODO -->
                     <TextBlock Text="Auto" Tag="0"/>

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
@@ -86,6 +86,8 @@ namespace JAFDTC.UI.A10C
             EditMisc.BullseyeOnHUD = Config.Misc.BullseyeOnHUD;
             EditMisc.FlightPlan1Manual = Config.Misc.FlightPlan1Manual;
             EditMisc.SpeedDisplay = Config.Misc.SpeedDisplay;
+            EditMisc.AapSteerPt = Config.Misc.AapSteerPt;
+            EditMisc.AapPage = Config.Misc.AapPage;
         }
 
         private void CopyEditToConfig(bool isPersist = false)
@@ -96,6 +98,8 @@ namespace JAFDTC.UI.A10C
                 Config.Misc.BullseyeOnHUD = EditMisc.BullseyeOnHUD;
                 Config.Misc.FlightPlan1Manual = EditMisc.FlightPlan1Manual;
                 Config.Misc.SpeedDisplay = EditMisc.SpeedDisplay;
+                Config.Misc.AapSteerPt = EditMisc.AapSteerPt;
+                Config.Misc.AapPage = EditMisc.AapPage;
 
                 if (isPersist)
                 {
@@ -160,6 +164,30 @@ namespace JAFDTC.UI.A10C
             }
         }
 
+        // rebuild the setup of the aap steer point according to the current settings. 
+        //
+        private void RebuildAapSteerPtSetup()
+        {
+            int aapSteerPt = (string.IsNullOrEmpty(EditMisc.AapSteerPt)) ? int.Parse(_miscSysDefault.AapSteerPt)
+                                                                             : int.Parse(EditMisc.AapSteerPt);
+            if (uiComboSteerPt.SelectedIndex != aapSteerPt)
+            {
+                uiComboSteerPt.SelectedIndex = aapSteerPt;
+            }
+        }
+
+        // rebuild the setup of the aap page according to the current settings. 
+        //
+        private void RebuildAapPageSetup()
+        {
+            int aapPage = (string.IsNullOrEmpty(EditMisc.AapPage)) ? int.Parse(_miscSysDefault.AapPage)
+                                                                             : int.Parse(EditMisc.AapPage);
+            if (uiComboPage.SelectedIndex != aapPage)
+            {
+                uiComboPage.SelectedIndex = aapPage;
+            }
+        }
+
         // TODO: document
         private void RebuildLinkControls()
         {
@@ -178,6 +206,8 @@ namespace JAFDTC.UI.A10C
             Utilities.SetEnableState(uiCkboxBullsOnHUD, isEditable);
             Utilities.SetEnableState(uiComboFlightPlan1Manual, isEditable);
             Utilities.SetEnableState(uiComboSpeedDisplay, isEditable);
+            Utilities.SetEnableState(uiComboSteerPt, isEditable);
+            Utilities.SetEnableState(uiComboPage, isEditable);
 
             Utilities.SetEnableState(uiPageBtnLink, _configNameList.Count > 0);
             Utilities.SetEnableState(uiPageBtnReset, !EditMisc.IsDefault);
@@ -197,6 +227,9 @@ namespace JAFDTC.UI.A10C
                     RebuildBullseyeOnHUDSetup();
                     RebuildFlightPlan1ManualSetup();
                     RebuildSpeedDisplaySetup();
+                    RebuildAapSteerPtSetup();
+                    RebuildAapPageSetup();
+
                     RebuildLinkControls();
                     RebuildEnableState();
                     IsRebuildingUI = false;
@@ -294,6 +327,31 @@ namespace JAFDTC.UI.A10C
             if (!IsRebuildingUI && (item != null) && (item.Tag != null))
             {
                 EditMisc.SpeedDisplay = (string)item.Tag;
+                CopyEditToConfig(true);
+            }
+        }
+
+        // ---- aap steer pt knob setup -------------------------------------------------------------------------------------------
+
+        private void ComboSteerPt_SelectionChanged(object sender, SelectionChangedEventArgs args)
+        {
+            TextBlock item = (TextBlock)((ComboBox)sender).SelectedItem;
+            if (!IsRebuildingUI && (item != null) && (item.Tag != null))
+            {
+                EditMisc.AapSteerPt = (string)item.Tag;
+                CopyEditToConfig(true);
+            }
+
+        }
+
+        // ---- aap page knob setup -------------------------------------------------------------------------------------------
+
+        private void ComboPage_SelectionChanged(object sender, SelectionChangedEventArgs args)
+        {
+            TextBlock item = (TextBlock)((ComboBox)sender).SelectedItem;
+            if (!IsRebuildingUI && (item != null) && (item.Tag != null))
+            {
+                EditMisc.AapPage = (string)item.Tag;
                 CopyEditToConfig(true);
             }
         }

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
@@ -83,6 +83,7 @@ namespace JAFDTC.UI.A10C
         private void CopyConfigToEdit()
         {
             EditMisc.CoordSystem = Config.Misc.CoordSystem;
+            EditMisc.BullseyeOnHUD = Config.Misc.BullseyeOnHUD;
             EditMisc.FlightPlan1Manual = Config.Misc.FlightPlan1Manual;
         }
 
@@ -91,6 +92,7 @@ namespace JAFDTC.UI.A10C
             if (!EditMisc.HasErrors)
             {
                 Config.Misc.CoordSystem = EditMisc.CoordSystem;
+                Config.Misc.BullseyeOnHUD = EditMisc.BullseyeOnHUD;
                 Config.Misc.FlightPlan1Manual = EditMisc.FlightPlan1Manual;
 
                 if (isPersist)
@@ -125,6 +127,13 @@ namespace JAFDTC.UI.A10C
             }
         }
 
+        // rebuild the setup of the bullseye on HUD setting according to the current settings. 
+        //
+        private void RebuildBullseyeOnHUDSetup()
+        {
+            uiCkboxBullsOnHUD.IsChecked = EditMisc.IsBullseyeOnHUDValue;
+        }
+
         // rebuild the setup of the first flight plan's manual setting according to the current settings. 
         //
         private void RebuildFlightPlan1ManualSetup()
@@ -152,6 +161,7 @@ namespace JAFDTC.UI.A10C
         {
             bool isEditable = string.IsNullOrEmpty(Config.SystemLinkedTo(MiscSystem.SystemTag));
             Utilities.SetEnableState(uiComboCoordSystem, isEditable);
+            Utilities.SetEnableState(uiCkboxBullsOnHUD, isEditable);
             Utilities.SetEnableState(uiComboFlightPlan1Manual, isEditable);
 
             Utilities.SetEnableState(uiPageBtnLink, _configNameList.Count > 0);
@@ -169,6 +179,7 @@ namespace JAFDTC.UI.A10C
                 {
                     IsRebuildingUI = true;
                     RebuildCoordSystemSetup();
+                    RebuildBullseyeOnHUDSetup();
                     RebuildFlightPlan1ManualSetup();
                     RebuildLinkControls();
                     RebuildEnableState();
@@ -231,6 +242,18 @@ namespace JAFDTC.UI.A10C
             if (!IsRebuildingUI && (item != null) && (item.Tag != null))
             {
                 EditMisc.CoordSystem = (string)item.Tag;
+                CopyEditToConfig(true);
+            }
+        }
+
+        // ---- bullseye on hud setup -------------------------------------------------------------------------------------------
+
+        private void uiCkboxBullsOnHUD_Click(object sender, RoutedEventArgs args)
+        {
+            CheckBox checkBox = (CheckBox)sender;
+            if (!IsRebuildingUI && (checkBox != null))
+            {
+                EditMisc.BullseyeOnHUD = checkBox.IsChecked.ToString();
                 CopyEditToConfig(true);
             }
         }

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
@@ -1,0 +1,268 @@
+using JAFDTC.UI.App;
+using JAFDTC.Models;
+using JAFDTC.Models.A10C;
+using JAFDTC.Models.A10C.Misc;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using System;
+using System.Collections.Generic;
+using Microsoft.UI.Dispatching;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace JAFDTC.UI.A10C
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class A10CEditMiscPage : Page
+    {
+        public static ConfigEditorPageInfo PageInfo
+            => new(MiscSystem.SystemTag, "Miscellaneous", "Miscellaneous", Glyphs.MISC, typeof(A10CEditMiscPage));
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // properties
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        private ConfigEditorPageNavArgs NavArgs { get; set; }
+
+        // NOTE: changes to the Config object may only occur through the marshall methods. bindings to and edits by
+        // NOTE: the ui are always directed at the EditMisc property.
+        //
+        private A10CConfiguration Config { get; set; }
+
+        private MiscSystem EditMisc { get; set; }
+
+        private bool IsRebuildPending { get; set; }
+
+        private bool IsRebuildingUI { get; set; }
+
+        // ---- read-only properties
+
+        private readonly MiscSystem _miscSysDefault;
+
+        private readonly Dictionary<string, string> _configNameToUID;
+        private readonly List<string> _configNameList;
+
+        private readonly Dictionary<string, TextBox> _baseFieldValueMap;
+        private readonly Brush _defaultBorderBrush;
+        private readonly Brush _defaultBkgndBrush;
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // construction
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        public A10CEditMiscPage()
+        {
+            this.InitializeComponent();
+            EditMisc = new MiscSystem();
+
+            IsRebuildPending = false;
+            IsRebuildingUI = false;
+
+            _miscSysDefault = MiscSystem.ExplicitDefaults;
+
+            _configNameToUID = new Dictionary<string, string>();
+            _configNameList = new List<string>();
+
+            // wait for final setup of the ui until we navigate to the page (at which point we will have a
+            // configuration to display).
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // data marshalling
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        // marshall data between our local misc setup and the configuration.
+        //
+        private void CopyConfigToEdit()
+        {
+            EditMisc.CoordSystem = Config.Misc.CoordSystem;
+        }
+
+        private void CopyEditToConfig(bool isPersist = false)
+        {
+            if (!EditMisc.HasErrors)
+            {
+                Config.Misc.CoordSystem = EditMisc.CoordSystem;
+
+                if (isPersist)
+                {
+                    Config.Save(this, MiscSystem.SystemTag);
+                }
+            }
+        }
+
+        // property changed: rebuild interface state to account for configuration changes.
+        //
+        private void BaseField_PropertyChanged(object sender, EventArgs args)
+        {
+            RebuildInterfaceState();
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // ui support
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        // rebuild the setup of the tacan band according to the current settings. 
+        //
+        private void RebuildCoordSystemSetup()
+        {
+            int band = (string.IsNullOrEmpty(EditMisc.CoordSystem)) ? int.Parse(_miscSysDefault.CoordSystem)
+                                                                  : int.Parse(EditMisc.CoordSystem);
+            if (uiComboCoordSystem.SelectedIndex != band)
+            {
+                uiComboCoordSystem.SelectedIndex = band;
+            }
+        }
+
+        // TODO: document
+        private void RebuildLinkControls()
+        {
+            Utilities.RebuildLinkControls(Config, MiscSystem.SystemTag, NavArgs.UIDtoConfigMap,
+                                          uiPageBtnTxtLink, uiPageTxtLink);
+        }
+
+
+        // update the enable state on the ui elements based on the current settings. link controls must be set up
+        // vi RebuildLinkControls() prior to calling this function.
+        //
+        private void RebuildEnableState()
+        {
+            bool isEditable = string.IsNullOrEmpty(Config.SystemLinkedTo(MiscSystem.SystemTag));
+            Utilities.SetEnableState(uiComboCoordSystem, isEditable);
+
+            Utilities.SetEnableState(uiPageBtnLink, _configNameList.Count > 0);
+            Utilities.SetEnableState(uiPageBtnReset, !EditMisc.IsDefault);
+        }
+
+        // rebuild the state of controls on the page in response to a change in the configuration.
+        //
+        private void RebuildInterfaceState()
+        {
+            if (!IsRebuildPending)
+            {
+                IsRebuildPending = true;
+                DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
+                {
+                    IsRebuildingUI = true;
+                    RebuildCoordSystemSetup();
+                    RebuildLinkControls();
+                    RebuildEnableState();
+                    IsRebuildingUI = false;
+                    IsRebuildPending = false;
+                });
+            }
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // ui interactions
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        // ---- page settings -----------------------------------------------------------------------------------------
+
+        // on clicks of the reset all button, reset all settings back to default.
+        //
+        private async void PageBtnReset_Click(object sender, RoutedEventArgs e)
+        {
+            ContentDialogResult result = await Utilities.Message2BDialog(
+                Content.XamlRoot,
+                "Reset Configruation?",
+                "Are you sure you want to reset the miscellaneous configurations to avionics defaults? This action cannot be undone.",
+                "Reset"
+            );
+            if (result == ContentDialogResult.Primary)
+            {
+                Config.UnlinkSystem(MiscSystem.SystemTag);
+                Config.Misc.Reset();
+                Config.Save(this, MiscSystem.SystemTag);
+                CopyConfigToEdit();
+            }
+        }
+
+        // TODO: document
+        private async void PageBtnLink_Click(object sender, RoutedEventArgs args)
+        {
+            string selectedItem = await Utilities.PageBtnLink_Click(Content.XamlRoot, Config, MiscSystem.SystemTag,
+                                                                    _configNameList);
+            if (selectedItem == null)
+            {
+                Config.UnlinkSystem(MiscSystem.SystemTag);
+                Config.Save(this);
+            }
+            else if (selectedItem.Length > 0)
+            {
+                Config.LinkSystemTo(MiscSystem.SystemTag, NavArgs.UIDtoConfigMap[_configNameToUID[selectedItem]]);
+                Config.Save(this);
+                CopyConfigToEdit();
+            }
+        }
+
+        // ---- tacan setup -------------------------------------------------------------------------------------------
+
+        private void ComboCoordSystem_SelectionChanged(object sender, RoutedEventArgs args)
+        {
+            TextBlock item = (TextBlock)((ComboBox)sender).SelectedItem;
+            if (!IsRebuildingUI && (item != null) && (item.Tag != null))
+            {
+                EditMisc.CoordSystem = (string)item.Tag;
+                CopyEditToConfig(true);
+            }
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // events
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        // on configuration saved, rebuild the interface state to align with the latest save (assuming we go here
+        // through a CopyEditToConfig).
+        //
+        private void ConfigurationSavedHandler(object sender, ConfigurationSavedEventArgs args)
+        {
+            RebuildInterfaceState();
+        }
+
+        // on navigating to/from this page, set up and tear down our internal and ui state based on the configuration
+        // we are editing.
+        //
+        protected override void OnNavigatedTo(NavigationEventArgs args)
+        {
+            NavArgs = (ConfigEditorPageNavArgs)args.Parameter;
+            Config = (A10CConfiguration)NavArgs.Config;
+
+            Config.ConfigurationSaved += ConfigurationSavedHandler;
+
+            Utilities.BuildSystemLinkLists(NavArgs.UIDtoConfigMap, Config.UID, MiscSystem.SystemTag,
+                                           _configNameList, _configNameToUID);
+
+            CopyConfigToEdit();
+
+            //ValidateAllFields(_baseFieldValueMap, EditMisc.GetErrors(null));
+            RebuildInterfaceState();
+
+            base.OnNavigatedTo(args);
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs args)
+        {
+            Config.ConfigurationSaved -= ConfigurationSavedHandler;
+
+            base.OnNavigatedFrom(args);
+        }
+    }
+}

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
@@ -88,6 +88,7 @@ namespace JAFDTC.UI.A10C
             EditMisc.SpeedDisplay = Config.Misc.SpeedDisplay;
             EditMisc.AapSteerPt = Config.Misc.AapSteerPt;
             EditMisc.AapPage = Config.Misc.AapPage;
+            EditMisc.AutopilotMode = Config.Misc.AutopilotMode;
         }
 
         private void CopyEditToConfig(bool isPersist = false)
@@ -100,6 +101,7 @@ namespace JAFDTC.UI.A10C
                 Config.Misc.SpeedDisplay = EditMisc.SpeedDisplay;
                 Config.Misc.AapSteerPt = EditMisc.AapSteerPt;
                 Config.Misc.AapPage = EditMisc.AapPage;
+                Config.Misc.AutopilotMode = EditMisc.AutopilotMode;
 
                 if (isPersist)
                 {
@@ -182,9 +184,25 @@ namespace JAFDTC.UI.A10C
         {
             int aapPage = (string.IsNullOrEmpty(EditMisc.AapPage)) ? int.Parse(_miscSysDefault.AapPage)
                                                                              : int.Parse(EditMisc.AapPage);
-            if (uiComboPage.SelectedIndex != aapPage)
+            if (uiComboAapPage.SelectedIndex != aapPage)
             {
-                uiComboPage.SelectedIndex = aapPage;
+                uiComboAapPage.SelectedIndex = aapPage;
+            }
+        }
+
+        // rebuild the setup of the autopilot mode according to the current settings. 
+        //
+        private void RebuildAutopilotModeSetup()
+        {
+            int autopilotMode = (string.IsNullOrEmpty(EditMisc.AutopilotMode)) ? int.Parse(_miscSysDefault.AutopilotMode)
+                                                                             : int.Parse(EditMisc.AutopilotMode);
+            foreach (TextBlock item in uiComboAutopilotMode.Items)
+            {
+                if ( int.Parse((string)item.Tag) == autopilotMode)
+                {
+                    uiComboAutopilotMode.SelectedItem = item;
+                    return;
+                }
             }
         }
 
@@ -207,7 +225,8 @@ namespace JAFDTC.UI.A10C
             Utilities.SetEnableState(uiComboFlightPlan1Manual, isEditable);
             Utilities.SetEnableState(uiComboSpeedDisplay, isEditable);
             Utilities.SetEnableState(uiComboSteerPt, isEditable);
-            Utilities.SetEnableState(uiComboPage, isEditable);
+            Utilities.SetEnableState(uiComboAapPage, isEditable);
+            Utilities.SetEnableState(uiComboAutopilotMode, isEditable);
 
             Utilities.SetEnableState(uiPageBtnLink, _configNameList.Count > 0);
             Utilities.SetEnableState(uiPageBtnReset, !EditMisc.IsDefault);
@@ -229,6 +248,7 @@ namespace JAFDTC.UI.A10C
                     RebuildSpeedDisplaySetup();
                     RebuildAapSteerPtSetup();
                     RebuildAapPageSetup();
+                    RebuildAutopilotModeSetup();
 
                     RebuildLinkControls();
                     RebuildEnableState();
@@ -352,6 +372,18 @@ namespace JAFDTC.UI.A10C
             if (!IsRebuildingUI && (item != null) && (item.Tag != null))
             {
                 EditMisc.AapPage = (string)item.Tag;
+                CopyEditToConfig(true);
+            }
+        }
+
+        // ---- autopilot mode switch setup -------------------------------------------------------------------------------------------
+
+        private void ComboAutopilotMode_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            TextBlock item = (TextBlock)((ComboBox)sender).SelectedItem;
+            if (!IsRebuildingUI && (item != null) && (item.Tag != null))
+            {
+                EditMisc.AutopilotMode = (string)item.Tag;
                 CopyEditToConfig(true);
             }
         }

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
@@ -85,6 +85,7 @@ namespace JAFDTC.UI.A10C
             EditMisc.CoordSystem = Config.Misc.CoordSystem;
             EditMisc.BullseyeOnHUD = Config.Misc.BullseyeOnHUD;
             EditMisc.FlightPlan1Manual = Config.Misc.FlightPlan1Manual;
+            EditMisc.SpeedDisplay = Config.Misc.SpeedDisplay;
         }
 
         private void CopyEditToConfig(bool isPersist = false)
@@ -94,6 +95,7 @@ namespace JAFDTC.UI.A10C
                 Config.Misc.CoordSystem = EditMisc.CoordSystem;
                 Config.Misc.BullseyeOnHUD = EditMisc.BullseyeOnHUD;
                 Config.Misc.FlightPlan1Manual = EditMisc.FlightPlan1Manual;
+                Config.Misc.SpeedDisplay = EditMisc.SpeedDisplay;
 
                 if (isPersist)
                 {
@@ -146,6 +148,18 @@ namespace JAFDTC.UI.A10C
             }
         }
 
+        // rebuild the setup of the speed display setting according to the current settings. 
+        //
+        private void RebuildSpeedDisplaySetup()
+        {
+            int speedDisplay = (string.IsNullOrEmpty(EditMisc.SpeedDisplay)) ? int.Parse(_miscSysDefault.SpeedDisplay)
+                                                                             : int.Parse(EditMisc.SpeedDisplay);
+            if (uiComboSpeedDisplay.SelectedIndex != speedDisplay)
+            {
+                uiComboSpeedDisplay.SelectedIndex = speedDisplay;
+            }
+        }
+
         // TODO: document
         private void RebuildLinkControls()
         {
@@ -163,6 +177,7 @@ namespace JAFDTC.UI.A10C
             Utilities.SetEnableState(uiComboCoordSystem, isEditable);
             Utilities.SetEnableState(uiCkboxBullsOnHUD, isEditable);
             Utilities.SetEnableState(uiComboFlightPlan1Manual, isEditable);
+            Utilities.SetEnableState(uiComboSpeedDisplay, isEditable);
 
             Utilities.SetEnableState(uiPageBtnLink, _configNameList.Count > 0);
             Utilities.SetEnableState(uiPageBtnReset, !EditMisc.IsDefault);
@@ -181,6 +196,7 @@ namespace JAFDTC.UI.A10C
                     RebuildCoordSystemSetup();
                     RebuildBullseyeOnHUDSetup();
                     RebuildFlightPlan1ManualSetup();
+                    RebuildSpeedDisplaySetup();
                     RebuildLinkControls();
                     RebuildEnableState();
                     IsRebuildingUI = false;
@@ -236,7 +252,7 @@ namespace JAFDTC.UI.A10C
 
         // ---- coordinate system setup -------------------------------------------------------------------------------------------
 
-        private void ComboCoordSystem_SelectionChanged(object sender, RoutedEventArgs args)
+        private void ComboCoordSystem_SelectionChanged(object sender, SelectionChangedEventArgs args)
         {
             TextBlock item = (TextBlock)((ComboBox)sender).SelectedItem;
             if (!IsRebuildingUI && (item != null) && (item.Tag != null))
@@ -260,12 +276,24 @@ namespace JAFDTC.UI.A10C
 
         // ---- flight plan 1 manual/auto setup -------------------------------------------------------------------------------------------
 
-        private void ComboFlightPlan1Manual_SelectionChanged(object sender, RoutedEventArgs args)
+        private void ComboFlightPlan1Manual_SelectionChanged(object sender, SelectionChangedEventArgs args)
         {
             TextBlock item = (TextBlock)((ComboBox)sender).SelectedItem;
             if (!IsRebuildingUI && (item != null) && (item.Tag != null))
             {
                 EditMisc.FlightPlan1Manual = (string)item.Tag;
+                CopyEditToConfig(true);
+            }
+        }
+
+        // ---- steer page speed display setup -------------------------------------------------------------------------------------------
+
+        private void ComboSpeedDisplay_SelectionChanged(object sender, SelectionChangedEventArgs args)
+        {
+            TextBlock item = (TextBlock)((ComboBox)sender).SelectedItem;
+            if (!IsRebuildingUI && (item != null) && (item.Tag != null))
+            {
+                EditMisc.SpeedDisplay = (string)item.Tag;
                 CopyEditToConfig(true);
             }
         }

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
@@ -49,10 +49,6 @@ namespace JAFDTC.UI.A10C
         private readonly Dictionary<string, string> _configNameToUID;
         private readonly List<string> _configNameList;
 
-        private readonly Dictionary<string, TextBox> _baseFieldValueMap;
-        private readonly Brush _defaultBorderBrush;
-        private readonly Brush _defaultBkgndBrush;
-
         // ------------------------------------------------------------------------------------------------------------
         //
         // construction

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
@@ -237,7 +237,7 @@ namespace JAFDTC.UI.A10C
 
         // ---- flight plan 1 manual/auto setup -------------------------------------------------------------------------------------------
 
-        private void ComboFPM01_SelectionChanged(object sender, RoutedEventArgs args)
+        private void ComboFlightPlan1Manual_SelectionChanged(object sender, RoutedEventArgs args)
         {
             TextBlock item = (TextBlock)((ComboBox)sender).SelectedItem;
             if (!IsRebuildingUI && (item != null) && (item.Tag != null))

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
@@ -83,6 +83,7 @@ namespace JAFDTC.UI.A10C
         private void CopyConfigToEdit()
         {
             EditMisc.CoordSystem = Config.Misc.CoordSystem;
+            EditMisc.FlightPlan1Manual = Config.Misc.FlightPlan1Manual;
         }
 
         private void CopyEditToConfig(bool isPersist = false)
@@ -90,6 +91,7 @@ namespace JAFDTC.UI.A10C
             if (!EditMisc.HasErrors)
             {
                 Config.Misc.CoordSystem = EditMisc.CoordSystem;
+                Config.Misc.FlightPlan1Manual = EditMisc.FlightPlan1Manual;
 
                 if (isPersist)
                 {
@@ -111,15 +113,27 @@ namespace JAFDTC.UI.A10C
         //
         // ------------------------------------------------------------------------------------------------------------
 
-        // rebuild the setup of the tacan band according to the current settings. 
+        // rebuild the setup of the coordinate system according to the current settings. 
         //
         private void RebuildCoordSystemSetup()
         {
-            int band = (string.IsNullOrEmpty(EditMisc.CoordSystem)) ? int.Parse(_miscSysDefault.CoordSystem)
+            int coordSystem = (string.IsNullOrEmpty(EditMisc.CoordSystem)) ? int.Parse(_miscSysDefault.CoordSystem)
                                                                   : int.Parse(EditMisc.CoordSystem);
-            if (uiComboCoordSystem.SelectedIndex != band)
+            if (uiComboCoordSystem.SelectedIndex != coordSystem)
             {
-                uiComboCoordSystem.SelectedIndex = band;
+                uiComboCoordSystem.SelectedIndex = coordSystem;
+            }
+        }
+
+        // rebuild the setup of the first flight plan's manual setting according to the current settings. 
+        //
+        private void RebuildFlightPlan1ManualSetup()
+        {
+            int manualOrAuto = (string.IsNullOrEmpty(EditMisc.FlightPlan1Manual)) ? int.Parse(_miscSysDefault.FlightPlan1Manual)
+                                                                          : int.Parse(EditMisc.FlightPlan1Manual);
+            if (uiComboFlightPlan1Manual.SelectedIndex != manualOrAuto)
+            {
+                uiComboFlightPlan1Manual.SelectedIndex = manualOrAuto;
             }
         }
 
@@ -138,6 +152,7 @@ namespace JAFDTC.UI.A10C
         {
             bool isEditable = string.IsNullOrEmpty(Config.SystemLinkedTo(MiscSystem.SystemTag));
             Utilities.SetEnableState(uiComboCoordSystem, isEditable);
+            Utilities.SetEnableState(uiComboFlightPlan1Manual, isEditable);
 
             Utilities.SetEnableState(uiPageBtnLink, _configNameList.Count > 0);
             Utilities.SetEnableState(uiPageBtnReset, !EditMisc.IsDefault);
@@ -154,6 +169,7 @@ namespace JAFDTC.UI.A10C
                 {
                     IsRebuildingUI = true;
                     RebuildCoordSystemSetup();
+                    RebuildFlightPlan1ManualSetup();
                     RebuildLinkControls();
                     RebuildEnableState();
                     IsRebuildingUI = false;
@@ -207,7 +223,7 @@ namespace JAFDTC.UI.A10C
             }
         }
 
-        // ---- tacan setup -------------------------------------------------------------------------------------------
+        // ---- coordinate system setup -------------------------------------------------------------------------------------------
 
         private void ComboCoordSystem_SelectionChanged(object sender, RoutedEventArgs args)
         {
@@ -215,6 +231,18 @@ namespace JAFDTC.UI.A10C
             if (!IsRebuildingUI && (item != null) && (item.Tag != null))
             {
                 EditMisc.CoordSystem = (string)item.Tag;
+                CopyEditToConfig(true);
+            }
+        }
+
+        // ---- flight plan 1 manual/auto setup -------------------------------------------------------------------------------------------
+
+        private void ComboFPM01_SelectionChanged(object sender, RoutedEventArgs args)
+        {
+            TextBlock item = (TextBlock)((ComboBox)sender).SelectedItem;
+            if (!IsRebuildingUI && (item != null) && (item.Tag != null))
+            {
+                EditMisc.FlightPlan1Manual = (string)item.Tag;
                 CopyEditToConfig(true);
             }
         }

--- a/JAFDTC/UI/A10C/A10CEditRadioPageHelper.cs
+++ b/JAFDTC/UI/A10C/A10CEditRadioPageHelper.cs
@@ -1,6 +1,6 @@
 ﻿// ********************************************************************************************************************
 //
-// A10CEditRadioPageHelper.cs : viper specialization for EditRadioPage
+// A10CEditRadioPageHelper.cs : A-10 specialization for EditRadioPage
 //
 // Copyright(C) 2023-2024 ilominar/raven, JAFDTC contributors
 //
@@ -23,7 +23,6 @@ using JAFDTC.Models.A10C;
 using JAFDTC.Models.A10C.Radio;
 using JAFDTC.UI.App;
 using JAFDTC.UI.Base;
-using JAFDTC.Utilities;
 using Microsoft.UI.Xaml.Controls;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;


### PR DESCRIPTION
This is based on the [a10-misc-system-additions branch](https://github.com/fizzle77/JAFDTC/tree/a10-misc-system-additions) and shouldn't be merged before #11.

Enables use of the Hog's excellent built-in elevation map to set ground level waypoints by leaving elevation blank in the waypoint editor.

Closes fizzle77#2.