### PR TITLE
Use unique integer IDs for A-10 munitions

### DIFF
--- a/JAFDTC/Data/db-a10-munitions.json
+++ b/JAFDTC/Data/db-a10-munitions.json
@@ -1,10 +1,11 @@
 [
 {
+	"ID": 1,
 	"Name": "CBU-87",
 	"Profile": "CBU-87",
 	"Image": "cbu-87-105.jpg",
 	"CCIP": true, "CCRP": true,
-	"EscMnvr": false, 
+	"EscMnvr": true, 
 	"AutoLase": false,
 	"Pairs": true, "Ripple": true, "RipFt": true,
 	"HOF": true, "RPM": true,
@@ -12,6 +13,7 @@
 	"INV_Keys": ["CBU-87"]
 },
 {
+	"ID": 2,
 	"Name": "CBU-97",
 	"Profile": "CBU-97",
 	"Image": "cbu-87-105.jpg",
@@ -24,11 +26,12 @@
 	"INV_Keys": ["CBU-97"]
 },
 {
+	"ID": 3,
 	"Name": "CBU-103",
 	"Profile": "CBU-103",
 	"Image": "cbu-87-105.jpg",
 	"CCIP": false, "CCRP": true,
-	"EscMnvr": true, 
+	"EscMnvr": false, 
 	"AutoLase": false,
 	"Pairs": false, "Ripple": false, "RipFt": false,
 	"HOF": true, "RPM": true,
@@ -36,6 +39,7 @@
 	"INV_Keys": ["CBU-103"]
 },
 {
+	"ID": 4,
 	"Name": "CBU-105",
 	"Profile": "CBU-105",
 	"Image": "cbu-87-105.jpg",
@@ -48,6 +52,7 @@
 	"INV_Keys": ["CBU-105"]
 },
 {
+	"ID": 5,
 	"Name": "GBU-12",
 	"Profile": "GBU-12",
 	"Image": "gbu-10-12.jpg",
@@ -61,6 +66,7 @@
 	"INV_Keys": ["GBU-12"]
 },
 {
+	"ID": 6,
 	"Name": "GBU-10",
 	"Profile": "GBU-10",
 	"Image": "gbu-10-12.jpg",
@@ -74,6 +80,7 @@
 	"INV_Keys": ["GBU-10"]
 },
 {
+	"ID": 7,
 	"Name": "GBU-31",
 	"Profile": "GBU-31",
 	"Image": "gbu-31.jpg",
@@ -86,6 +93,7 @@
 	"INV_Keys": ["GBU-31"]
 },
 {
+	"ID": 8,
 	"Name": "GBU-38",
 	"Profile": "GBU-38",
 	"Image": "gbu-31.jpg",
@@ -98,6 +106,7 @@
 	"INV_Keys": ["GBU-38"]
 },
 {
+	"ID": 9,
 	"Name": "GBU-54",
 	"Profile": "GBU-54",
 	"Image": "gbu-31.jpg",
@@ -111,6 +120,7 @@
 	"INV_Keys": ["GBU-54"]
 },
 {
+	"ID": 10,
 	"Name": "M151 HE APKWS",
 	"Profile": "M151L",
 	"Image": "agr.jpg",
@@ -124,6 +134,7 @@
 	"INV_Keys": ["M-151L"]
 },
 {
+	"ID": 11,
 	"Name": "M282 MPP APKWS",
 	"Profile": "M282L",
 	"Image": "agr.jpg",
@@ -137,6 +148,7 @@
 	"INV_Keys": ["M-282L"]
 },
 {
+	"ID": 12,
 	"Name": "IR/CCD Mavericks",
 	"Profile": "MAVERICK",
 	"Image": "agm-65d.jpg",
@@ -149,6 +161,7 @@
 	"INV_Keys": ["AGM-65D", "AGM-65G", "AGM-65H", "AGM-65K"]
 },
 {
+	"ID": 13,
 	"Name": "Laser Mavericks",
 	"Profile": "MAVERICK",
 	"Image": "agm-65l.jpg",

--- a/JAFDTC/Models/A10C/A10CMunition.cs
+++ b/JAFDTC/Models/A10C/A10CMunition.cs
@@ -79,7 +79,7 @@ namespace JAFDTC.Models.A10C
         {
             if (_profileList == null)
             {
-                _profileList = FileManager.LoadA10Munitions();
+                _profileList = GetMunitions();
                 // HACK: duplicate maverick profiles don't  matter, so we remove the duplicate entry.
                 // They don't matter because the Maverick has no real profile settings.
                 A10CMunition toRemove = null;
@@ -121,9 +121,7 @@ namespace JAFDTC.Models.A10C
             {
                 _idMunitionMap = new Dictionary<int, A10CMunition>();
                 foreach (A10CMunition munition in GetMunitions())
-                {
-                    _idMunitionMap.Add(ID, munition);
-                }
+                    _idMunitionMap.Add(munition.ID, munition);
             }
             return _idMunitionMap[ID];
         }

--- a/JAFDTC/Models/A10C/A10CMunition.cs
+++ b/JAFDTC/Models/A10C/A10CMunition.cs
@@ -21,7 +21,6 @@
 
 using JAFDTC.Utilities;
 using System.Collections.Generic;
-using Windows.Media.Streaming.Adaptive;
 
 namespace JAFDTC.Models.A10C
 {
@@ -30,7 +29,8 @@ namespace JAFDTC.Models.A10C
         //
         // properties deserialized from DB JSON
         //
-        public string Name { get; set; } // name as it will apper in UI. Must be unique.
+        public int ID { get; set; } // ID used in configuration files. Must be unique.
+        public string Name { get; set; } // name as it will apper in UI.
         public string Profile { get; set; } // name of the weapon's default profile
         public string Image { get; set; } // name of the weapon's image file
 
@@ -85,7 +85,7 @@ namespace JAFDTC.Models.A10C
                 A10CMunition toRemove = null;
                 foreach (A10CMunition m in _profileList)
                 {
-                    if (m.Name == "Laser Mavericks")
+                    if (m.ID == 13)
                     {
                         toRemove = m;
                         break;
@@ -113,19 +113,19 @@ namespace JAFDTC.Models.A10C
             return _keyMunitionMap[key];
         }
 
-        // Name to Munition Map
-        private static Dictionary<string, A10CMunition> _nameMunitionMap;
-        public static A10CMunition GetMunitionFromName(string name)
+        // ID to Munition Map
+        private static Dictionary<int, A10CMunition> _idMunitionMap;
+        public static A10CMunition GetMunitionFromID(int ID)
         {
-            if (_nameMunitionMap == null)
+            if (_idMunitionMap == null)
             {
-                _nameMunitionMap = new Dictionary<string, A10CMunition>();
+                _idMunitionMap = new Dictionary<int, A10CMunition>();
                 foreach (A10CMunition munition in GetMunitions())
                 {
-                    _nameMunitionMap.Add(name, munition);
+                    _idMunitionMap.Add(ID, munition);
                 }
             }
-            return _nameMunitionMap[name];
+            return _idMunitionMap[ID];
         }
 
         // Profile to Munition Map
@@ -144,18 +144,5 @@ namespace JAFDTC.Models.A10C
                 return m;
             return null;
         }
-
-        //private static Dictionary<string, string> _profileKeyMap;
-        //public static string GetInvKeyFromDefaultProfileName(string profileName)
-        //{
-        //    if (_profileKeyMap == null)
-        //    {
-        //        _profileKeyMap = new Dictionary<string, string>();
-        //        foreach (A10CMunition munition in GetMunitions())
-        //            _profileKeyMap.Add(munition.Profile, munition.Key);
-        //    }
-        //    return _profileKeyMap[profileName];
-        //}
-
     }
 }

--- a/JAFDTC/Models/A10C/A10CMunition.cs
+++ b/JAFDTC/Models/A10C/A10CMunition.cs
@@ -30,7 +30,7 @@ namespace JAFDTC.Models.A10C
         // properties deserialized from DB JSON
         //
         public int ID { get; set; } // ID used in configuration files. Must be unique.
-        public string Name { get; set; } // name as it will apper in UI.
+        public string Name { get; set; } // name as it will appear in UI.
         public string Profile { get; set; } // name of the weapon's default profile
         public string Image { get; set; } // name of the weapon's image file
 

--- a/JAFDTC/Models/A10C/DSMS/DSMSSystem.cs
+++ b/JAFDTC/Models/A10C/DSMS/DSMSSystem.cs
@@ -131,7 +131,7 @@ namespace JAFDTC.Models.A10C.DSMS
         private Dictionary<int, MunitionSettings> _munitionSettingMap;
 
         public bool IsProfileOrderEnabled { get; set; }
-        public List<string> ProfileOrder { get; set; }
+        public List<int> ProfileOrder { get; set; }
 
         // ---- synthesized properties
 
@@ -203,7 +203,10 @@ namespace JAFDTC.Models.A10C.DSMS
                 {
                     _orderedProfilePositions = new Dictionary<string, int>(ProfileOrder.Count);
                     for (int i = 0; i < ProfileOrder.Count; i++)
-                        _orderedProfilePositions.Add(ProfileOrder[i], i);
+                    {
+                        A10CMunition m = A10CMunition.GetMunitionFromID(ProfileOrder[i]);
+                        _orderedProfilePositions.Add(m.Profile, i);
+                    }
                 }
             }
 

--- a/JAFDTC/Models/A10C/DSMS/DSMSSystem.cs
+++ b/JAFDTC/Models/A10C/DSMS/DSMSSystem.cs
@@ -123,12 +123,12 @@ namespace JAFDTC.Models.A10C.DSMS
         }
 
         [JsonPropertyName("MunitionSettings")]
-        public Dictionary<string, MunitionSettings> MunitionSettingMap
+        public Dictionary<int, MunitionSettings> MunitionSettingMap
         {
             get => _munitionSettingMap;
             set => _munitionSettingMap = value;
         }
-        private Dictionary<string, MunitionSettings> _munitionSettingMap;
+        private Dictionary<int, MunitionSettings> _munitionSettingMap;
 
         public bool IsProfileOrderEnabled { get; set; }
         public List<string> ProfileOrder { get; set; }
@@ -220,10 +220,10 @@ namespace JAFDTC.Models.A10C.DSMS
         public MunitionSettings GetMunitionSettings(A10CMunition munition)
         {
             MunitionSettings settings;
-            if (!_munitionSettingMap.TryGetValue(munition.Name, out settings))
+            if (!_munitionSettingMap.TryGetValue(munition.ID, out settings))
             {
                 settings = new MunitionSettings(munition);
-                _munitionSettingMap.Add(munition.Name, settings);
+                _munitionSettingMap.Add(munition.ID, settings);
             }
             return settings;
         }
@@ -232,7 +232,7 @@ namespace JAFDTC.Models.A10C.DSMS
         public void Reset()
         {
             LaserCode = "";
-            _munitionSettingMap = new Dictionary<string, MunitionSettings>();
+            _munitionSettingMap = new Dictionary<int, MunitionSettings>();
             ProfileOrder = null;
             IsProfileOrderEnabled = false;
         }
@@ -242,7 +242,7 @@ namespace JAFDTC.Models.A10C.DSMS
             List<A10CMunition> munitions = A10CMunition.GetMunitions();
             foreach (var munition in munitions)
             {
-                if (_munitionSettingMap.TryGetValue(munition.Name, out MunitionSettings setting))
+                if (_munitionSettingMap.TryGetValue(munition.ID, out MunitionSettings setting))
                     setting.Munition = munition;
             }
         }
@@ -256,12 +256,12 @@ namespace JAFDTC.Models.A10C.DSMS
         public Dictionary<string, MunitionSettings> GetNonDefaultInvSettings()
         {
             Dictionary<string, MunitionSettings> settings = new Dictionary<string, MunitionSettings>();
-            foreach (KeyValuePair<string, MunitionSettings> kv in _munitionSettingMap)
+            foreach (MunitionSettings munSettings in _munitionSettingMap.Values)
             {
-                if (!kv.Value.IsInvDefault)
-                    AddMunitionSettingsWithAllInvKeysToDictionary(settings, kv.Value);
-                else if (kv.Value != null && kv.Value.Munition.Laser && !IsLaserCodeDefault)
-                    AddMunitionSettingsWithAllInvKeysToDictionary(settings, kv.Value);
+                if (!munSettings.IsInvDefault)
+                    AddMunitionSettingsWithAllInvKeysToDictionary(settings, munSettings);
+                else if (munSettings != null && munSettings.Munition.Laser && !IsLaserCodeDefault)
+                    AddMunitionSettingsWithAllInvKeysToDictionary(settings, munSettings);
             }
 
             // If laser code is non-default, ensure all laser weapons are added to list
@@ -285,10 +285,10 @@ namespace JAFDTC.Models.A10C.DSMS
         }
 
         // Get munition settings that have non-default settings on the profiles page.
-        public Dictionary<string, MunitionSettings> GetNonDefaultProfileSettings()
+        public Dictionary<int, MunitionSettings> GetNonDefaultProfileSettings()
         {
-            Dictionary<string, MunitionSettings> settings = new Dictionary<string, MunitionSettings>();
-            foreach (KeyValuePair<string, MunitionSettings> kv in _munitionSettingMap)
+            Dictionary<int, MunitionSettings> settings = new Dictionary<int, MunitionSettings>();
+            foreach (KeyValuePair<int, MunitionSettings> kv in _munitionSettingMap)
             {
                 if (!kv.Value.IsProfileDefault)
                     settings.Add(kv.Key, kv.Value);

--- a/JAFDTC/Models/A10C/Upload/DSMSBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/DSMSBuilder.cs
@@ -178,14 +178,14 @@ namespace JAFDTC.Models.A10C.Upload
         private void Build_DefaultProfiles(AirframeDevice cdu, AirframeDevice lmfd)
         {
             // get configs that require profile changes
-            Dictionary<string, MunitionSettings> nonDefaultSettings = _cfg.DSMS.GetNonDefaultProfileSettings();
+            Dictionary<int, MunitionSettings> nonDefaultSettings = _cfg.DSMS.GetNonDefaultProfileSettings();
             if (nonDefaultSettings == null || nonDefaultSettings.Count == 0)
                 return;
 
             AddActions(lmfd, new() { "LMFD_14", "LMFD_01" }, null, WAIT_BASE); // Go to DSMS Profiles
             int selectedProfileIndex = 0;
 
-            foreach (KeyValuePair<string, int> kv in _profileQuery.MunitionProfileIndexMap)
+            foreach (KeyValuePair<int, int> kv in _profileQuery.MunitionProfileIndexMap)
             {
                 if (nonDefaultSettings.TryGetValue(kv.Key, out MunitionSettings settings))
                 {

--- a/JAFDTC/Models/A10C/Upload/DSMSQueries.cs
+++ b/JAFDTC/Models/A10C/Upload/DSMSQueries.cs
@@ -57,7 +57,7 @@ namespace JAFDTC.Models.A10C.Upload
         /// </summary>
         private class DSMSProfileQueryBuilder : QueryBuilderBase, IBuilder
         {
-            private Dictionary<string, int> _munitionProfileIndexMap { set; get; }
+            private Dictionary<int, int> _munitionProfileIndexMap { set; get; }
 
             private List<string > _profiles;
             public List<string> Profiles
@@ -70,7 +70,10 @@ namespace JAFDTC.Models.A10C.Upload
                 }
             }
 
-            public Dictionary<string, int> MunitionProfileIndexMap
+            /// <summary>
+            /// In the returned dictionary, keys are munition IDs and values are the 0-based index in the jet's default profiles.
+            /// </summary>
+            public Dictionary<int, int> MunitionProfileIndexMap
             {
                 get
                 {
@@ -83,7 +86,7 @@ namespace JAFDTC.Models.A10C.Upload
             // lazy load and cache the query data
             private void DoQuery()
             {
-                _munitionProfileIndexMap = new Dictionary<string, int>();
+                _munitionProfileIndexMap = new Dictionary<int, int>();
                 _profiles = new List<string>();
                 Build();
                 // 1=WPNS OFF;2=GBU-54;3=MAVERICK;...
@@ -97,7 +100,7 @@ namespace JAFDTC.Models.A10C.Upload
 
                         A10CMunition m = A10CMunition.GetMunitionFromProfile(kv[1]);
                         if (m != null)
-                            _munitionProfileIndexMap.Add(m.Name, int.Parse(kv[0]) - 1);
+                            _munitionProfileIndexMap.Add(m.ID, int.Parse(kv[0]) - 1);
                     }
                 }
             }

--- a/JAFDTC/UI/A10C/A10CEditDSMSProfileOrder.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditDSMSProfileOrder.xaml.cs
@@ -29,9 +29,9 @@ namespace JAFDTC.UI.A10C
 
         private void SaveEditStateToConfig()
         {
-            List<string> newOrder = new List<string>(_munitions.Count);
+            List<int> newOrder = new List<int>(_munitions.Count);
             foreach (A10CMunition m in _munitions)
-                newOrder.Add(m.Profile);
+                newOrder.Add(m.ID);
             _config.DSMS.ProfileOrder = newOrder;
             _config.Save(this, SystemTag);
         }
@@ -51,8 +51,8 @@ namespace JAFDTC.UI.A10C
             {
                 for (int newIndex = 0; newIndex < _munitions.Count; newIndex++)
                 {
-                    string profileName = _config.DSMS.ProfileOrder[newIndex];
-                    A10CMunition m = A10CMunition.GetMunitionFromProfile(profileName);
+                    int munitionID = _config.DSMS.ProfileOrder[newIndex];
+                    A10CMunition m = A10CMunition.GetMunitionFromID(munitionID);
                     if (m != null)
                     {
                         int oldIndex = _munitions.IndexOf(m);


### PR DESCRIPTION
As mentioned in #29.

I expect the merge of the munitions json file with your branch will be gross. You can safely just add the IDs by hand if it's easier, just note two other fixes I made, toggling the `EscMnvr` value for the CBU-87 and CBU-103 on lines 7 and 31, respectively.