### PR TITLE
A10 DSMS: more UI tweaks

### DIFF
--- a/JAFDTC/Models/A10C/DSMS/DSMSSystem.cs
+++ b/JAFDTC/Models/A10C/DSMS/DSMSSystem.cs
@@ -130,7 +130,6 @@ namespace JAFDTC.Models.A10C.DSMS
         }
         private Dictionary<int, MunitionSettings> _munitionSettingMap;
 
-        public bool IsProfileOrderEnabled { get; set; }
         public List<int> ProfileOrder { get; set; }
 
         // ---- synthesized properties
@@ -160,7 +159,7 @@ namespace JAFDTC.Models.A10C.DSMS
         public bool IsLaserCodeDefault => string.IsNullOrEmpty(LaserCode) || LaserCode == ExplicitDefaults.LaserCode;
 
         [JsonIgnore]
-        public bool IsProfileOrderDefault => ProfileOrder == null || ProfileOrder.Count == 0 || IsProfileOrderEnabled == false;
+        public bool IsProfileOrderDefault => ProfileOrder == null || ProfileOrder.Count == 0;
 
         // ------------------------------------------------------------------------------------------------------------
         //
@@ -177,7 +176,6 @@ namespace JAFDTC.Models.A10C.DSMS
         {
             LaserCode = other.LaserCode;
             _munitionSettingMap = other._munitionSettingMap;
-            IsProfileOrderEnabled = other.IsProfileOrderEnabled;
             ProfileOrder = other.ProfileOrder;
         }
 
@@ -237,7 +235,6 @@ namespace JAFDTC.Models.A10C.DSMS
             LaserCode = "";
             _munitionSettingMap = new Dictionary<int, MunitionSettings>();
             ProfileOrder = null;
-            IsProfileOrderEnabled = false;
         }
 
         internal void FixupMunitionReferences()

--- a/JAFDTC/Models/A10C/DSMS/DSMSSystem.cs
+++ b/JAFDTC/Models/A10C/DSMS/DSMSSystem.cs
@@ -146,12 +146,7 @@ namespace JAFDTC.Models.A10C.DSMS
             {
                 if (!IsLaserCodeDefault || !IsProfileOrderDefault)
                     return false;
-                foreach (MunitionSettings setting in _munitionSettingMap.Values)
-                {
-                    if (!setting.IsDefault)
-                        return false;
-                }
-                return true;
+                return AreAllMunitionSettingsDefault;
             }
         }
 
@@ -160,6 +155,21 @@ namespace JAFDTC.Models.A10C.DSMS
 
         [JsonIgnore]
         public bool IsProfileOrderDefault => ProfileOrder == null || ProfileOrder.Count == 0;
+
+        [JsonIgnore]
+        public bool AreAllMunitionSettingsDefault
+        {
+            get
+            {
+                foreach (MunitionSettings setting in _munitionSettingMap.Values)
+                {
+                    if (!setting.IsDefault)
+                        return false;
+                }
+                return true;
+            }
+        }
+           
 
         // ------------------------------------------------------------------------------------------------------------
         //

--- a/JAFDTC/Models/A10C/DSMS/MunitionSettings.cs
+++ b/JAFDTC/Models/A10C/DSMS/MunitionSettings.cs
@@ -176,7 +176,30 @@ namespace JAFDTC.Models.A10C.DSMS
         [JsonIgnore]
         public bool IsLaseSecondsDefault => string.IsNullOrEmpty(LaseSeconds) || LaseSeconds == ExplicitDefaults.LaseSeconds;
         [JsonIgnore]
-        public bool IsDeliveryModeDefault => string.IsNullOrEmpty(DeliveryMode) || DeliveryMode == ExplicitDefaults.DeliveryMode || DeliveryMode == "-1";
+        public bool IsDeliveryModeDefault 
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(DeliveryMode) || DeliveryMode == "-1")
+                    return true;
+                if (_munition == null)
+                    return true;
+                if (_munition.CCIP ^ _munition.CCRP)
+                {
+                    // For the weapons that only allow one of CCIP or CCRP, ensure the one they allow is treated as default.
+                    if (_munition.CCIP && DeliveryMode == ((int)DeliveryModes.CCIP).ToString())
+                        return true;
+                    if (_munition.CCRP && DeliveryMode == ((int)DeliveryModes.CCRP).ToString())
+                        return true;
+                }
+                else
+                {
+                    // For weapons that support both, CCIP is the default, specified in ExplicitDefaults.
+                    return DeliveryMode == ExplicitDefaults.DeliveryMode;
+                }
+                return false;
+            }
+        }
         [JsonIgnore]
         public bool IsEscapeManeuverDefault => string.IsNullOrEmpty(EscapeManeuver) || EscapeManeuver == ExplicitDefaults.EscapeManeuver || EscapeManeuver == "-1";
         [JsonIgnore]

--- a/JAFDTC/UI/A10C/A10CEditDSMSMunitionSettingsPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditDSMSMunitionSettingsPage.xaml
@@ -56,12 +56,25 @@ https://www.gnu.org/licenses/.
                   ToolTipService.ToolTip="Select munition to alter settings">
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="local:A10CMunition">
-                    <StackPanel Orientation="Horizontal" Height="48">
-                        <Image Margin="0,4,0,4" Source="{x:Bind ImageFullPath}" VerticalAlignment="Center"/>
-                        <TextBlock Text="{x:Bind Name}" VerticalAlignment="Center" 
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="20"/>
+                            <ColumnDefinition Width="48"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="48"/>
+                        </Grid.RowDefinitions>
+                        <FontIcon Grid.Column="0" Tag="icon"
+                                  VerticalAlignment="Center"
+                                  Visibility="Collapsed"
+                                  Foreground="{ThemeResource SystemAccentColor}"
+                                  FontFamily="Segoe Fluent Icons" Glyph="&#xE915;"/>
+                        <Image Grid.Column="1" Margin="0,4,0,4" Source="{x:Bind ImageFullPath}" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="2" Text="{x:Bind Name}" VerticalAlignment="Center" 
                                    Style="{ThemeResource EditorParamStaticTextBlockStyle}" 
                                    Margin="6,0,0,0" />
-                    </StackPanel>
+                    </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>

--- a/JAFDTC/UI/A10C/A10CEditDSMSMunitionSettingsPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditDSMSMunitionSettingsPage.xaml.cs
@@ -20,7 +20,6 @@
 using JAFDTC.Models;
 using JAFDTC.Models.A10C;
 using JAFDTC.Models.A10C.DSMS;
-using JAFDTC.UI.App;
 using JAFDTC.Utilities;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
@@ -33,6 +32,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using static JAFDTC.Models.A10C.DSMS.DSMSSystem;
+using static JAFDTC.UI.A10C.A10CEditDSMSPage;
 
 namespace JAFDTC.UI.A10C
 {
@@ -41,7 +41,7 @@ namespace JAFDTC.UI.A10C
     /// </summary>
     public sealed partial class A10CEditDSMSMunitionSettingsPage : Page, IA10CDSMSContentFrame
     {
-        private ConfigEditorPageNavArgs _navArgs;
+        private DSMSEditorNavArgs _dsmsEditorNavArgs;
         private A10CConfiguration _config;
         private readonly DSMSSystem _editState;
 
@@ -196,7 +196,7 @@ namespace JAFDTC.UI.A10C
                 _config.DSMS.SetFuzeOption(selectedMunition, _editState.GetFuzeOption(selectedMunition));
             }
 
-            _config.Save(this, SystemTag);
+            _config.Save(_dsmsEditorNavArgs.ParentPage, SystemTag);
         }
 
         public void CopyConfigToEditState()
@@ -365,8 +365,8 @@ namespace JAFDTC.UI.A10C
 
         protected override void OnNavigatedTo(NavigationEventArgs args)
         {
-            _navArgs = (ConfigEditorPageNavArgs)args.Parameter;
-            _config = (A10CConfiguration)_navArgs.Config;
+            _dsmsEditorNavArgs = (DSMSEditorNavArgs)args.Parameter;
+            _config = (A10CConfiguration)_dsmsEditorNavArgs.NavArgs.Config;
 
             _config.ConfigurationSaved += ConfigurationSavedHandler;
 

--- a/JAFDTC/UI/A10C/A10CEditDSMSMunitionSettingsPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditDSMSMunitionSettingsPage.xaml.cs
@@ -164,6 +164,8 @@ namespace JAFDTC.UI.A10C
                 uiLabelFuse.Visibility = fuzeVisible;
                 uiComboFuze.Visibility = fuzeVisible;
 
+                UpdateNonDefaultMunitionIcons();
+
                 MunitionSettings newSettings = _editState.GetMunitionSettings(selectedMunition);
                 newSettings.ErrorsChanged += BaseField_DataValidationError;
                 newSettings.PropertyChanged += BaseField_PropertyChanged;
@@ -230,6 +232,22 @@ namespace JAFDTC.UI.A10C
         {
             selectedMunition = (A10CMunition)uiComboMunition.SelectedItem;
             return selectedMunition != null;
+        }
+
+        private void UpdateNonDefaultMunitionIcons()
+        {
+            foreach (A10CMunition munition in uiComboMunition.Items)
+            {
+                UIElement container = (UIElement)uiComboMunition.ContainerFromItem(munition);
+                FontIcon icon = Utilities.FindControl<FontIcon>(container, typeof(FontIcon), "icon");
+                if (icon != null)
+                {
+                    if (_config.DSMS.GetMunitionSettings(munition).IsDefault)
+                        icon.Visibility = Visibility.Collapsed;
+                    else
+                        icon.Visibility = Visibility.Visible;
+                }
+            }
         }
 
         // ---- event handlers -------------------------------------------------------------------------------------------

--- a/JAFDTC/UI/A10C/A10CEditDSMSPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditDSMSPage.xaml
@@ -30,9 +30,41 @@ https://www.gnu.org/licenses/.
     <NavigationView PaneDisplayMode="Top" IsSettingsVisible="False" IsBackButtonVisible="Collapsed"
                     SelectionChanged="NavigationView_SelectionChanged">
         <NavigationView.MenuItems>
-            <NavigationViewItem x:Name="uiMunitionTab" Content="Munition Settings" IsSelected="True"/>
+            <NavigationViewItem x:Name="uiMunitionTab" IsSelected="True">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="20"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <FontIcon Grid.Column="0"
+                                  x:Name="uiIconMunitionTab"
+                                  VerticalAlignment="Center"
+                                  Foreground="{ThemeResource SystemAccentColor}"
+                                  FontFamily="Segoe Fluent Icons" Glyph="&#xE915;"/>
+                    <TextBlock Grid.Column="1" Margin="8,0,0,0"
+                                   VerticalAlignment="Center">
+                            Munition Settings
+                    </TextBlock>
+                </Grid>
+            </NavigationViewItem>
             <NavigationViewItemSeparator/>
-            <NavigationViewItem x:Name="uiProfileTab" Content="Profile Order" />
+            <NavigationViewItem x:Name="uiProfileTab">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="20"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <FontIcon Grid.Column="0"
+                                  x:Name="uiIconProfileTab"
+                                  VerticalAlignment="Center"
+                                  Foreground="{ThemeResource SystemAccentColor}"
+                                  FontFamily="Segoe Fluent Icons" Glyph="&#xE915;"/>
+                    <TextBlock Grid.Column="1" Margin="8,0,0,0"
+                                   VerticalAlignment="Center">
+                            Profile Order
+                    </TextBlock>
+                </Grid>
+            </NavigationViewItem>
         </NavigationView.MenuItems>
 
         <Grid Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush }">

--- a/JAFDTC/UI/A10C/A10CEditDSMSPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditDSMSPage.xaml
@@ -22,7 +22,6 @@ https://www.gnu.org/licenses/.
     x:Class="JAFDTC.UI.A10C.A10CEditDSMSPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:JAFDTC.Models.A10C"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
@@ -47,7 +46,7 @@ https://www.gnu.org/licenses/.
             </Grid.ColumnDefinitions>
 
             <!-- DSMS Content Frame -->
-            <Frame x:Name="DSMSContentFrame" Grid.Row="0" Grid.Column="0" VerticalAlignment="Top" HorizontalAlignment="Left" />
+            <Frame x:Name="DSMSContentFrame" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Top" />
 
             <!--
             ===============================================================================================================

--- a/JAFDTC/UI/A10C/A10CEditDSMSPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditDSMSPage.xaml.cs
@@ -38,6 +38,19 @@ namespace JAFDTC.UI.A10C
     /// </summary>
     public sealed partial class A10CEditDSMSPage : Page
     {
+        internal class DSMSEditorNavArgs
+        {
+            internal ConfigEditorPageNavArgs NavArgs { get; }
+            internal A10CEditDSMSPage ParentPage { get; }
+
+            internal DSMSEditorNavArgs(ConfigEditorPageNavArgs navArgs, A10CEditDSMSPage parentPage)
+            {
+                NavArgs = navArgs;
+                ParentPage = parentPage;
+            }
+        }
+
+        private DSMSEditorNavArgs _dsmsEditorNavArgs;
         private ConfigEditorPageNavArgs _navArgs;
         private A10CConfiguration _config;
 
@@ -58,9 +71,9 @@ namespace JAFDTC.UI.A10C
         private void NavigationView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
         {
             if (ReferenceEquals(args.SelectedItem, uiMunitionTab))
-                DSMSContentFrame.Navigate(typeof(A10CEditDSMSMunitionSettingsPage), _navArgs);
+                DSMSContentFrame.Navigate(typeof(A10CEditDSMSMunitionSettingsPage), _dsmsEditorNavArgs);
             else if (ReferenceEquals(args.SelectedItem, uiProfileTab))
-                DSMSContentFrame.Navigate(typeof(A10CEditDSMSProfileOrderPage), _navArgs);
+                DSMSContentFrame.Navigate(typeof(A10CEditDSMSProfileOrderPage), _dsmsEditorNavArgs);
             else
                 throw new ApplicationException("Unexpected NavigationViewItem type");
         }
@@ -111,6 +124,7 @@ namespace JAFDTC.UI.A10C
         protected override void OnNavigatedTo(NavigationEventArgs args)
         {
             _navArgs = (ConfigEditorPageNavArgs)args.Parameter;
+            _dsmsEditorNavArgs = new DSMSEditorNavArgs(_navArgs, this);
             _config = (A10CConfiguration)_navArgs.Config;
 
             Utilities.BuildSystemLinkLists(_navArgs.UIDtoConfigMap, _config.UID, DSMSSystem.SystemTag,

--- a/JAFDTC/UI/A10C/A10CEditDSMSPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditDSMSPage.xaml.cs
@@ -25,6 +25,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using System;
 using System.Collections.Generic;
+using JAFDTC.Models;
 
 namespace JAFDTC.UI.A10C
 {
@@ -76,6 +77,19 @@ namespace JAFDTC.UI.A10C
                 DSMSContentFrame.Navigate(typeof(A10CEditDSMSProfileOrderPage), _dsmsEditorNavArgs);
             else
                 throw new ApplicationException("Unexpected NavigationViewItem type");
+        }
+
+        private void UpdateNonDefaultIcons() 
+        {
+            if (_config.DSMS.IsLaserCodeDefault && _config.DSMS.AreAllMunitionSettingsDefault)
+                uiIconMunitionTab.Visibility = Visibility.Collapsed;
+            else
+                uiIconMunitionTab.Visibility = Visibility.Visible;
+
+            if (_config.DSMS.IsProfileOrderDefault)
+                uiIconProfileTab.Visibility = Visibility.Collapsed;
+            else
+                uiIconProfileTab.Visibility = Visibility.Visible;
         }
 
         // ---- page settings -----------------------------------------------------------------------------------------
@@ -130,9 +144,23 @@ namespace JAFDTC.UI.A10C
             Utilities.BuildSystemLinkLists(_navArgs.UIDtoConfigMap, _config.UID, DSMSSystem.SystemTag,
                                            _configNameList, _configNameToUID);
 
+            _config.ConfigurationSaved += ConfigurationSavedHandler;
+
+            UpdateNonDefaultIcons();
             UpdateLinkControls();
 
             base.OnNavigatedTo(args);
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            _config.ConfigurationSaved -= ConfigurationSavedHandler;
+            base.OnNavigatedFrom(e);
+        }
+
+        private void ConfigurationSavedHandler(object sender, ConfigurationSavedEventArgs args)
+        {
+            UpdateNonDefaultIcons();
         }
 
         private void UpdateLinkControls()

--- a/JAFDTC/UI/A10C/A10CEditDSMSProfileOrder.xaml
+++ b/JAFDTC/UI/A10C/A10CEditDSMSProfileOrder.xaml
@@ -42,12 +42,20 @@ https://www.gnu.org/licenses/.
             SelectionMode="None" AllowDrop="True" CanReorderItems="True" DragItemsCompleted="uiListProfiles_DragItemsCompleted">
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="local:A10CMunition">
-                    <StackPanel Orientation="Horizontal" Height="48">
-                        <Image Margin="0,4,0,4" Source="{x:Bind ImageFullPath}" VerticalAlignment="Center"/>
-                        <TextBlock Text="{x:Bind Profile}" VerticalAlignment="Center" 
-                            Style="{ThemeResource EditorParamStaticTextBlockStyle}" 
-                            Margin="6,0,0,0" />
-                    </StackPanel>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="20"/> <!-- Always empty here, but matching the layout on the munition settings tab. -->
+                            <ColumnDefinition Width="48"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="48"/>
+                        </Grid.RowDefinitions>
+                        <Image Grid.Column="1" Margin="0,4,0,4" Source="{x:Bind ImageFullPath}" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="2" Text="{x:Bind Profile}" VerticalAlignment="Center" 
+                                   Style="{ThemeResource EditorParamStaticTextBlockStyle}" 
+                                   Margin="6,0,0,0" />
+                    </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>

--- a/JAFDTC/UI/A10C/A10CEditDSMSProfileOrder.xaml
+++ b/JAFDTC/UI/A10C/A10CEditDSMSProfileOrder.xaml
@@ -28,33 +28,32 @@ https://www.gnu.org/licenses/.
     mc:Ignorable="d"
     Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}">
 
-    <Grid HorizontalAlignment="Left" VerticalAlignment="Top">
+    <Grid VerticalAlignment="Top">
         <Grid.ColumnDefinitions>
-            <ColumnDefinition/>
             <ColumnDefinition/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
-            <RowDefinition/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         
-        <ListView x:Name="uiListProfiles" Grid.Row="0" Grid.Column="0" ItemsSource="{x:Bind _munitions}" CanDragItems="True"
+        <ListView x:Name="uiListProfiles" Grid.Row="0" Grid.Column="0" HorizontalAlignment="Left"
+                  ItemsSource="{x:Bind _munitions}" CanDragItems="True" Width="175"
             SelectionMode="None" AllowDrop="True" CanReorderItems="True" DragItemsCompleted="uiListProfiles_DragItemsCompleted">
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="local:A10CMunition">
                     <StackPanel Orientation="Horizontal" Height="48">
-                        <FontIcon Margin="0,0,6,0" FontFamily="Segoe Fluent Icons" FontSize="24" Glyph="&#xE76F;"/>
-                        <Image Source="{x:Bind ImageFullPath}" VerticalAlignment="Center"/>
+                        <Image Margin="0,4,0,4" Source="{x:Bind ImageFullPath}" VerticalAlignment="Center"/>
                         <TextBlock Text="{x:Bind Profile}" VerticalAlignment="Center" 
                             Style="{ThemeResource EditorParamStaticTextBlockStyle}" 
-                            Margin="12,0,0,0" />
+                            Margin="6,0,0,0" />
                     </StackPanel>
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
 
-        <CheckBox x:Name="uiCheckUseOrder" Grid.Row="0" Grid.Column="1" VerticalAlignment="Top" Margin="18,18,12,12"
-            IsChecked="{x:Bind _config.DSMS.IsProfileOrderEnabled, Mode=TwoWay}" Click="uiCheckUseOrder_Click">
-            Order default weapon profiles as shown
-        </CheckBox>
+        <TextBlock Grid.Row="1" Grid.Column="0" HorizontalAlignment="Center" Margin="0,12,0,12">
+            Drag to adjust the order of default weapon profiles in the jet.
+        </TextBlock>
     </Grid>
 </Page>

--- a/JAFDTC/UI/A10C/A10CEditDSMSProfileOrder.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditDSMSProfileOrder.xaml.cs
@@ -24,6 +24,7 @@ using Microsoft.UI.Xaml.Navigation;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using static JAFDTC.Models.A10C.DSMS.DSMSSystem;
+using static JAFDTC.UI.A10C.A10CEditDSMSPage;
 
 namespace JAFDTC.UI.A10C
 {
@@ -32,7 +33,7 @@ namespace JAFDTC.UI.A10C
     /// </summary>
     public sealed partial class A10CEditDSMSProfileOrderPage : Page, IA10CDSMSContentFrame
     {
-        private ConfigEditorPageNavArgs _navArgs;
+        private DSMSEditorNavArgs _dsmsEditorNavArgs;
         private A10CConfiguration _config;
 
         private ObservableCollection<A10CMunition> _munitions;
@@ -43,7 +44,7 @@ namespace JAFDTC.UI.A10C
         {
             _munitions = new ObservableCollection<A10CMunition>(A10CMunition.GetUniqueProfileMunitions());
 
-            this.InitializeComponent();
+            InitializeComponent();
         }
 
         private void SaveEditStateToConfig()
@@ -52,7 +53,7 @@ namespace JAFDTC.UI.A10C
             foreach (A10CMunition m in _munitions)
                 newOrder.Add(m.ID);
             _config.DSMS.ProfileOrder = newOrder;
-            _config.Save(this, SystemTag);
+            _config.Save(_dsmsEditorNavArgs.ParentPage, SystemTag);
         }
 
         public void CopyConfigToEditState()
@@ -64,7 +65,6 @@ namespace JAFDTC.UI.A10C
             {
                 _munitions = new ObservableCollection<A10CMunition>(A10CMunition.GetUniqueProfileMunitions());
                 uiListProfiles.ItemsSource = _munitions;
-                uiCheckUseOrder.IsChecked = _config.DSMS.IsProfileOrderEnabled;
             }
             else
             {
@@ -82,7 +82,6 @@ namespace JAFDTC.UI.A10C
 
             bool isNotLinked = string.IsNullOrEmpty(_config.SystemLinkedTo(SystemTag));
             uiListProfiles.IsEnabled = isNotLinked;
-            uiCheckUseOrder.IsEnabled = isNotLinked;
         }
 
         private void uiListProfiles_DragItemsCompleted(ListViewBase sender, DragItemsCompletedEventArgs args)
@@ -92,16 +91,10 @@ namespace JAFDTC.UI.A10C
             _suspendUIUpdates = false;
         }
 
-        private void uiCheckUseOrder_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
-        {
-            SaveEditStateToConfig();
-            _config.Save(this, SystemTag);
-        }
-
         protected override void OnNavigatedTo(NavigationEventArgs args)
         {
-            _navArgs = (ConfigEditorPageNavArgs)args.Parameter;
-            _config = (A10CConfiguration)_navArgs.Config;
+            _dsmsEditorNavArgs = (DSMSEditorNavArgs)args.Parameter;
+            _config = (A10CConfiguration)_dsmsEditorNavArgs.NavArgs.Config;
 
             CopyConfigToEditState();
 

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
@@ -615,7 +615,6 @@ namespace JAFDTC.UI.A10C
 
             CopyConfigToEdit();
 
-            //ValidateAllFields(_baseFieldValueMap, EditMisc.GetErrors(null));
             RebuildInterfaceState();
 
             base.OnNavigatedTo(args);


### PR DESCRIPTION
1. Addresses feedback in #36:

![profile-order](https://github.com/51st-Vfw/JAFDTC/assets/42720583/a67df9b0-adf0-4d69-a520-b099014b3951)

2. Adds blue non-default indicators where relevant: the top tabs and individual munitions:

![munition-settings](https://github.com/51st-Vfw/JAFDTC/assets/42720583/66f5a0be-d016-4fe7-8f4c-78dcc8cc8d44)

3. Fixes a bug that prevented the DSMS editor UI indication of default/non-default status from updating correctly.

4. Fixes a bug in the way default status was determined for weapons that only support CCRP.

Feedback on UI details welcome, as ever. The profile order page is still a little weird, but it truly is useful so I want to find a way to keep it!