### PR TITLE
A-10C HMCS Page UI Tweaks

### DIFF
--- a/JAFDTC/UI/A10C/A10CEditHMCSPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditHMCSPage.xaml
@@ -34,14 +34,18 @@ https://www.gnu.org/licenses/.
             <Setter Property="HorizontalAlignment" Value="Right"/>
             <Setter Property="Margin" Value="12,12,0,0"/>
         </Style>
-        <Style x:Key="ValueBase" BasedOn="{StaticResource Base}" TargetType="TextBox">
+        <Style x:Key="ValueBase" BasedOn="{StaticResource DefaultTextBoxStyle}" TargetType="TextBox">
+            <Setter Property="VerticalAlignment" Value="Center"/>
             <Setter Property="HorizontalAlignment" Value="Left"/>
-            <Setter Property="Margin" Value="12,12,24,0"/>
+            <Setter Property="Margin" Value="12,12,0,0"/>
             <Setter Property="MaxLength" Value="3" />
             <Setter Property="PlaceholderText" Value="50" />
         </Style>
-        <Style x:Key="ComboBase" BasedOn="{StaticResource Base}" TargetType="ComboBox">
+        <Style x:Key="ComboBase" BasedOn="{StaticResource DefaultComboBoxStyle}" TargetType="ComboBox">
             <Setter Property="Width" Value="90"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="HorizontalAlignment" Value="Right"/>
+            <Setter Property="Margin" Value="12,12,0,0"/>
         </Style>
         <Style x:Key="TextBase" BasedOn="{StaticResource Base}" TargetType="TextBlock">
             <Setter Property="HorizontalAlignment" Value="Left"/>
@@ -49,8 +53,11 @@ https://www.gnu.org/licenses/.
         <Style x:Key="TopRowBase" BasedOn="{StaticResource Base}" TargetType="FrameworkElement">
             <Setter Property="Margin" Value="12,12,0,0"/>
         </Style>
-        <Style x:Key="TopRowCombo" BasedOn="{StaticResource TopRowBase}" TargetType="ComboBox">
+        <Style x:Key="TopRowCombo" BasedOn="{StaticResource DefaultComboBoxStyle}" TargetType="ComboBox">
             <Setter Property="Width" Value="90"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="HorizontalAlignment" Value="Right"/>
+            <Setter Property="Margin" Value="12,12,0,0"/>
         </Style>
         <Style x:Key="TopRowText" BasedOn="{StaticResource TopRowBase}" TargetType="TextBlock">
             <Setter Property="HorizontalAlignment" Value="Left"/>
@@ -88,7 +95,7 @@ https://www.gnu.org/licenses/.
         ===============================================================================================================
         -->
         <StackPanel Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
-            <ComboBox Margin="24,0,0,0" Width="200"
+            <ComboBox Margin="24,12,0,6" Width="200"
                       x:Name="uiComboEditProfile"
                       SelectionChanged="uiComboEditProfile_SelectionChanged"
                       VerticalAlignment="Center"
@@ -141,13 +148,13 @@ https://www.gnu.org/licenses/.
                     </Grid>
                 </ComboBox.Items>
             </ComboBox>
-            <Button Margin="24,0,6,0" VerticalAlignment="Center"
+            <Button Margin="24,12,6,6" VerticalAlignment="Center"
                     x:Name="uiButtonPrev"
                     ToolTipService.ToolTip="Select previous profile"
                     Click="uiButtonPrev_Click">
                 <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE70E;"/>
             </Button>
-            <Button VerticalAlignment="Center"
+            <Button Margin="0,12,6,6" VerticalAlignment="Center"
                     x:Name="uiButtonNext"
                     ToolTipService.ToolTip="Select next profile"
                     Click="uiButtonNext_Click">
@@ -160,7 +167,7 @@ https://www.gnu.org/licenses/.
         rows 1 and 2 : profile settings
         ===============================================================================================================
         -->
-        <TextBlock Grid.Row="1" Style="{StaticResource EditorTitleTextBlockStyle}">
+        <TextBlock Grid.Row="1" Margin="16,0,16,0" Style="{StaticResource EditorTitleTextBlockStyle}">
             Profile-Specific Settings:
         </TextBlock>
 
@@ -460,7 +467,7 @@ https://www.gnu.org/licenses/.
                 <RowDefinition/>
             </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="0" Style="{StaticResource EditorTitleTextBlockStyle}">
+            <TextBlock Grid.Row="0" Margin="16,0,16,0" Style="{StaticResource EditorTitleTextBlockStyle}">
                 Common HMCS Settings:
             </TextBlock>
 


### PR DESCRIPTION
Changed styles to derive from DefaultComboBoxStyle and DefaultTextBoxStyle to preserve default widget shapes.

This fix restores the default rounded TextBlock/ComboBox shapes for consistency. The inheritance in the Styles is no longer as clean as a result, you can thank MSFT for the weird hierarchy. :)

I get the text alignment matches the jet, but after staring at this for a bit, I think I'd group things differently to better align with the rest of the UI. Rather than use indentation to group, maybe additional vertical space to set off groups of related settings? Also, not sure if there's functional meaning of the indentation: for example, setting "Own SPI" to "OFF" disables indented "SPI Indicator" row.