### PR TITLE
Major A10 UI Refactor

### DIFF
--- a/JAFDTC/JAFDTC.csproj
+++ b/JAFDTC/JAFDTC.csproj
@@ -62,6 +62,7 @@
     <None Remove="UI\Base\EditNavpointPage.xaml" />
     <None Remove="UI\Base\EditRadioPage.xaml" />
     <None Remove="UI\BlankPage1.xaml" />
+    <None Remove="UI\Controls\LinkResetBtnsControl.xaml" />
     <None Remove="UI\F15E\F15EEditMiscPage.xaml" />
     <None Remove="UI\F15E\F15EEditMPDPage.xaml" />
     <None Remove="UI\F15E\F15EEditSteerpointListPage.xaml" />
@@ -167,6 +168,9 @@
     <None Update="Images\gbu-54.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Page Update="UI\Controls\LinkResetBtnsControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Update="UI\A10C\A10CEditTADPage.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/JAFDTC/Models/A10C/DSMS/MunitionSettings.cs
+++ b/JAFDTC/Models/A10C/DSMS/MunitionSettings.cs
@@ -245,53 +245,51 @@ namespace JAFDTC.Models.A10C.DSMS
         {
             get
             {
-                if (string.IsNullOrEmpty(DeliveryMode) || DeliveryMode == "-1")
+                if (string.IsNullOrEmpty(DeliveryMode))
                     return true;
                 if (_munition == null)
                     return true;
-                if (_munition.CCIP ^ _munition.CCRP)
-                {
-                    // For the weapons that only allow one of CCIP or CCRP, ensure the one they allow is treated as default.
-                    if (_munition.CCIP && DeliveryMode == ((int)DeliveryModes.CCIP).ToString())
-                        return true;
-                    if (_munition.CCRP && DeliveryMode == ((int)DeliveryModes.CCRP).ToString())
-                        return true;
-                }
-                else
-                {
-                    // For weapons that support both, CCIP is the default, specified in ExplicitDefaults.
-                    return DeliveryMode == ExplicitDefaults.DeliveryMode;
-                }
-                return false;
+                return DeliveryMode == DefaultDeliveryMode;
             }
         }
         [JsonIgnore]
-        public bool IsEscapeManeuverDefault => string.IsNullOrEmpty(EscapeManeuver) || EscapeManeuver == ExplicitDefaults.EscapeManeuver || EscapeManeuver == "-1";
+        public bool IsEscapeManeuverDefault => string.IsNullOrEmpty(EscapeManeuver) || EscapeManeuver == ExplicitDefaults.EscapeManeuver;
         [JsonIgnore]
-        public bool IsReleaseModeDefault => string.IsNullOrEmpty(ReleaseMode) || ReleaseMode == ExplicitDefaults.ReleaseMode || ReleaseMode == "-1";
+        public bool IsReleaseModeDefault => string.IsNullOrEmpty(ReleaseMode) || ReleaseMode == ExplicitDefaults.ReleaseMode;
         [JsonIgnore]
         public bool IsRippleQtyDefault => string.IsNullOrEmpty(RippleQty) || RippleQty == ExplicitDefaults.RippleQty;
         [JsonIgnore]
         public bool IsRippleFtDefault => string.IsNullOrEmpty(RippleFt) || RippleFt == ExplicitDefaults.RippleFt;
         [JsonIgnore]
-        public bool IsHOFOptionDefault => string.IsNullOrEmpty(HOFOption) || HOFOption == ExplicitDefaults.HOFOption || HOFOption == "-1";
+        public bool IsHOFOptionDefault => string.IsNullOrEmpty(HOFOption) || HOFOption == ExplicitDefaults.HOFOption;
         [JsonIgnore]
-        public bool IsRPMOptionDefault => string.IsNullOrEmpty(RPMOption) || RPMOption == ExplicitDefaults.RPMOption || RPMOption == "-1";
+        public bool IsRPMOptionDefault => string.IsNullOrEmpty(RPMOption) || RPMOption == ExplicitDefaults.RPMOption;
         [JsonIgnore]
-        public bool IsFuzeOptionDefault => string.IsNullOrEmpty(FuzeOption) || FuzeOption == ExplicitDefaults.FuzeOption || FuzeOption == "-1";
+        public bool IsFuzeOptionDefault => string.IsNullOrEmpty(FuzeOption) || FuzeOption == ExplicitDefaults.FuzeOption;
+
+        [JsonIgnore]
+        public string DefaultDeliveryMode
+        {
+            get
+            {
+                if (_munition == null || _munition.CCIP)
+                    return "0";
+                return "1";
+            }
+        }
 
         public readonly static MunitionSettings ExplicitDefaults = new()
         {
             AutoLase = "False",
             LaseSeconds = "0",
-            DeliveryMode = "0", // CCIP
-            EscapeManeuver = "1", // CLB
-            ReleaseMode = "0", // SGL
+            DeliveryMode = "",
+            EscapeManeuver = "1",   // CLB
+            ReleaseMode = "0",      // SGL
             RippleQty = "1",
             RippleFt = "75",
-            HOFOption = "6", // 1800
-            RPMOption = "3", // 1500
-            FuzeOption = "0" // N/T
+            HOFOption = "6",        // 1800
+            RPMOption = "3",        // 1500
+            FuzeOption = "0"        // N/T
         };
 
         private MunitionSettings()
@@ -306,16 +304,16 @@ namespace JAFDTC.Models.A10C.DSMS
 
         public override void Reset()
         {
-            AutoLase = "";
-            LaseSeconds = "";
+            AutoLase = "False";
+            LaseSeconds = "0";
             DeliveryMode = "";
-            EscapeManeuver = "";
-            ReleaseMode = "";
-            RippleQty = "";
-            RippleFt = "";
-            HOFOption = "";
-            RPMOption = "";
-            FuzeOption = "";
+            EscapeManeuver = "1";   // CLB
+            ReleaseMode = "0";      // SGL
+            RippleQty = "1";
+            RippleFt = "75";
+            HOFOption = "6";        // 1800
+            RPMOption = "3";        // 1500
+            FuzeOption = "0";       // N/T
         }
     }
 }

--- a/JAFDTC/Models/A10C/Misc/MiscSystem.cs
+++ b/JAFDTC/Models/A10C/Misc/MiscSystem.cs
@@ -186,13 +186,13 @@ namespace JAFDTC.Models.A10C.Misc
             }
         }
 
-        private string _autopilotMode;                              // integer [-1, 1]
+        private string _autopilotMode;                              // integer [0, 2]
         public string AutopilotMode
         {
             get => _autopilotMode;
             set
             {
-                string error = (string.IsNullOrEmpty(value) || IsIntegerFieldValid(value, -1, 1)) ? null : "Invalid format";
+                string error = (string.IsNullOrEmpty(value) || IsIntegerFieldValid(value, 0, 2)) ? null : "Invalid format";
                 SetProperty(ref _autopilotMode, value, error);
             }
         }

--- a/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
@@ -223,7 +223,13 @@ namespace JAFDTC.Models.A10C.Upload
             if (miscSystem.IsAutopilotModeDefault)
                 return; // Alt/Hdg
 
-            int setValue = (int)miscSystem.AutopilotModeValue;
+            int setValue = miscSystem.AutopilotModeValue switch
+            {
+                AutopilotModeOptions.Path => 1,
+                AutopilotModeOptions.AltHdg => 0,
+                AutopilotModeOptions.Alt => -1,
+                _ => throw new NotImplementedException()
+            };
             AddDynamicAction(ap, "AP_MODE", setValue, setValue);
         }
 

--- a/JAFDTC/Models/Configuration.cs
+++ b/JAFDTC/Models/Configuration.cs
@@ -239,6 +239,8 @@ namespace JAFDTC.Models
             return ((LinkedSysMap != null) && LinkedSysMap.ContainsKey(systemTag)) ? LinkedSysMap[systemTag] : null;
         }
 
+        public bool IsLinked(string systemTag) => !string.IsNullOrEmpty(SystemLinkedTo(systemTag));
+
         public void CleanupSystemLinks(List<string> validUIDs)
         {
             List<string> invalidUIDs = new();

--- a/JAFDTC/Models/IConfiguration.cs
+++ b/JAFDTC/Models/IConfiguration.cs
@@ -185,6 +185,11 @@ namespace JAFDTC.Models
         /// <summary>
         /// TODO: document
         /// </summary>
+        public bool IsLinked(string systemTag);
+
+        /// <summary>
+        /// TODO: document
+        /// </summary>
         public void CleanupSystemLinks(List<string> validUIDs);
 
         /// <summary>

--- a/JAFDTC/UI/A10C/A10CEditDSMSMunitionSettingsPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditDSMSMunitionSettingsPage.xaml
@@ -18,12 +18,12 @@ https://www.gnu.org/licenses/.
 
 **********************************************************************************************************************
 -->
-<Page
+<ui:A10CPageBase
     x:Class="JAFDTC.UI.A10C.A10CEditDSMSMunitionSettingsPage"
+    xmlns:ui="using:JAFDTC.UI.A10C"
+    xmlns:models="using:JAFDTC.Models.A10C"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:JAFDTC.Models.A10C"
-    xmlns:dsms="using:JAFDTC.Models.A10C.DSMS"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
@@ -55,7 +55,7 @@ https://www.gnu.org/licenses/.
                   SelectionChanged="ComboMunition_SelectionChanged"
                   ToolTipService.ToolTip="Select munition to alter settings">
             <ListView.ItemTemplate>
-                <DataTemplate x:DataType="local:A10CMunition">
+                <DataTemplate x:DataType="models:A10CMunition">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="20"/>
@@ -118,14 +118,16 @@ https://www.gnu.org/licenses/.
                      HorizontalAlignment="Stretch" VerticalAlignment="Center"
                      Style="{StaticResource EditorParamEditTextBoxStyle}"
                      MaxLength="4" PlaceholderText="1688"
-                     LosingFocus="TextLaserCode_LosingFocus"
+                     LosingFocus="TextBox_LosingFocus"
+                     GotFocus="TextBox_GotFocus"
+                     Tag="LaserCode"
                      ToolTipService.ToolTip="Laser code the selected munition will track"/>
 
-            <!-- Munition Settings (Dedicated)
+            <!-- Munition Settings (Selected)
               -->
             <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,24,0,0"
                        Style="{StaticResource EditorTitleTextBlockStyle}">
-                Dedicated Munition Settings:
+                Selected Munition Settings:
             </TextBlock>
 
             <!-- Delivery Mode (CCIP/CCRP) -->
@@ -136,7 +138,8 @@ https://www.gnu.org/licenses/.
             </TextBlock>
             <ComboBox Grid.Row="3" Grid.Column="1" Margin="12,12,0,0" x:Name="uiComboDeliveryMode"
                       HorizontalAlignment="Stretch" VerticalAlignment="Center"
-                      SelectionChanged="ComboDeliveryMode_SelectionChanged">
+                      SelectionChanged="ComboBox_SelectionChanged"
+                      Tag="DeliveryMode">
                 <!-- Must match order of A10C.DSMSSystem.DeliveryModes -->
                 <ComboBoxItem>CCIP</ComboBoxItem>
                 <ComboBoxItem>CCRP</ComboBoxItem>
@@ -150,7 +153,8 @@ https://www.gnu.org/licenses/.
             </TextBlock>
             <ComboBox Grid.Row="4" Grid.Column="1" Margin="12,12,0,0" x:Name="uiComboReleaseMode"
                       HorizontalAlignment="Stretch" VerticalAlignment="Center"
-                      SelectionChanged="ComboReleaseMode_SelectionChanged">
+                      SelectionChanged="ComboBox_SelectionChanged"
+                      Tag="ReleaseMode">
                 <ComboBoxItem>SGL</ComboBoxItem>
                 <ComboBoxItem>PRS</ComboBoxItem>
                 <ComboBoxItem>RIP SGL</ComboBoxItem>
@@ -158,27 +162,31 @@ https://www.gnu.org/licenses/.
             </ComboBox>
             <StackPanel Grid.Row="4" Grid.Column="2" Margin="12,12,0,0" x:Name="uiStackRipple"
                         Orientation="Horizontal">
-                <TextBlock Style="{ThemeResource EditorParamStaticTextBlockStyle}" VerticalAlignment="Center">
+                <TextBlock Style="{ThemeResource EditorParamStaticTextBlockStyle}" VerticalAlignment="Center" x:Name="uiLabelRipple">
                     Ripple
                 </TextBlock>
                 <TextBox Width="64" Margin="12,0,0,0" x:Name="uiTextRippleQty"
                          HorizontalAlignment="Left" VerticalAlignment="Center"
                          Style="{StaticResource EditorParamEditTextBoxStyle}"
                          MaxLength="2" PlaceholderText="1"
-                         LosingFocus="TextRippleQty_LosingFocus"
+                         LosingFocus="TextBox_LosingFocus"
+                         GotFocus="TextBox_GotFocus"
+                         Tag="RippleQty"
                          ToolTipService.ToolTip="Number of munitions to release per weapons release depression"/>
                 <TextBlock Margin="6,0,0,0"
                            VerticalAlignment="Center"
-                           Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                           Style="{ThemeResource EditorParamStaticTextBlockStyle}"  x:Name="uiLabelRippleAt">
                     at
                 </TextBlock>
                 <TextBox Width="64" Margin="8,0,0,0" x:Name="uiTextRippleFt"
                          HorizontalAlignment="Left" VerticalAlignment="Center"
                          Style="{StaticResource EditorParamEditTextBoxStyle}"
                          MaxLength="3" PlaceholderText="75"
-                         LosingFocus="TextRippleFt_LosingFocus"
+                         LosingFocus="TextBox_LosingFocus"
+                         GotFocus="TextBox_GotFocus"
+                         Tag="RippleFt"
                          ToolTipService.ToolTip="Distance between impacts, in feet"/>
-                <TextBlock Style="{ThemeResource EditorParamStaticTextBlockStyle}" VerticalAlignment="Center" Margin="6,0,0,0">
+                <TextBlock Style="{ThemeResource EditorParamStaticTextBlockStyle}" VerticalAlignment="Center" Margin="6,0,0,0" x:Name="uiLabelRippleUnits">
                     ft
                 </TextBlock>
             </StackPanel>
@@ -191,7 +199,8 @@ https://www.gnu.org/licenses/.
             </TextBlock>
             <ComboBox Grid.Row="5" Grid.Column="1" Margin="12,12,0,0" x:Name="uiComboEscMnvr"
                       HorizontalAlignment="Stretch" VerticalAlignment="Center"
-                      SelectionChanged="ComboEscMnvr_SelectionChanged">
+                      SelectionChanged="ComboBox_SelectionChanged"
+                      Tag="EscapeManeuver">
                 <!-- Must match order of A10C.DSMSSystem.EscapeManeuvers -->
                 <ComboBoxItem>NONE</ComboBoxItem>
                 <ComboBoxItem>CLB</ComboBoxItem>
@@ -207,7 +216,8 @@ https://www.gnu.org/licenses/.
             </TextBlock>
             <ComboBox Grid.Row="6" Grid.Column="1" Margin="12,12,0,0" x:Name="uiComboHOF"
                       HorizontalAlignment="Stretch" VerticalAlignment="Center"
-                      SelectionChanged="ComboHOF_SelectionChanged">
+                      SelectionChanged="ComboBox_SelectionChanged"
+                      Tag="HOFOption">
                 <ComboBoxItem>300</ComboBoxItem>
                 <ComboBoxItem>500</ComboBoxItem>
                 <ComboBoxItem>700</ComboBoxItem>
@@ -228,7 +238,8 @@ https://www.gnu.org/licenses/.
                 </TextBlock>
                 <ComboBox Margin="6,0,0,0" x:Name="uiComboRPM"
                           VerticalAlignment="Center"
-                          SelectionChanged="ComboRPM_SelectionChanged">
+                          SelectionChanged="ComboBox_SelectionChanged"
+                          Tag="RPMOption">
                     <ComboBoxItem>0</ComboBoxItem>
                     <ComboBoxItem>500</ComboBoxItem>
                     <ComboBoxItem>1000</ComboBoxItem>
@@ -246,7 +257,8 @@ https://www.gnu.org/licenses/.
             </TextBlock>
             <ComboBox Grid.Row="7" Grid.Column="1" Margin="12,12,0,0" x:Name="uiComboFuze"
                       HorizontalAlignment="Stretch" VerticalAlignment="Center"
-                      SelectionChanged="ComboFuze_SelectionChanged">
+                      SelectionChanged="ComboBox_SelectionChanged"
+                      Tag="FuzeOption">
                 <ComboBoxItem>N/T</ComboBoxItem>
                 <ComboBoxItem>N</ComboBoxItem>
                 <ComboBoxItem>T</ComboBoxItem>
@@ -261,12 +273,15 @@ https://www.gnu.org/licenses/.
             <StackPanel Grid.Row="8" Grid.Column="1" Margin="12,12,0,0" x:Name="uiStackAutoLase"
                         Orientation="Horizontal">
                 <CheckBox Width="32" MinWidth="32" x:Name="uiCheckAutoLase"
-                          Checked="CheckAutoLase_Changed" Unchecked="CheckAutoLase_Changed"/>
+                          Click="CheckBox_Clicked"
+                          Tag="AutoLase"/>
                 <TextBox Width="84" Margin="0,0,0,0" x:Name="uiTextLaseTime"
                          HorizontalAlignment="Left" VerticalAlignment="Center"
                          Style="{StaticResource EditorParamEditTextBoxStyle}"
                          MaxLength="2" PlaceholderText="0"
-                         LosingFocus="TextLaseTime_LosingFocus"
+                         LosingFocus="TextBox_LosingFocus"
+                         GotFocus="TextBox_GotFocus"
+                         Tag="LaseSeconds"
                          ToolTipService.ToolTip="Seconds before impact to automatically start the laser firing"/>
             </StackPanel>
             <TextBlock Grid.Row="8" Grid.Column="2" Margin="6,12,0,0" x:Name="uiLabelLaseTimeUnits"
@@ -289,4 +304,4 @@ https://www.gnu.org/licenses/.
 
         </Grid>
     </Grid>
-</Page>
+</ui:A10CPageBase>

--- a/JAFDTC/UI/A10C/A10CEditDSMSPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditDSMSPage.xaml
@@ -18,8 +18,10 @@ https://www.gnu.org/licenses/.
 
 **********************************************************************************************************************
 -->
-<Page
+<local:A10CPageBase
     x:Class="JAFDTC.UI.A10C.A10CEditDSMSPage"
+    xmlns:local="using:JAFDTC.UI.A10C"
+    xmlns:controls="using:JAFDTC.UI.Controls"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -85,49 +87,8 @@ https://www.gnu.org/licenses/.
             link / reset
             ===============================================================================================================
             -->
-            <Grid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Margin="12,12,12,12">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
+            <controls:LinkResetBtnsControl x:Name="uiCtlLinkResetBtns" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"/>
 
-                <StackPanel Grid.Column="0"
-                        VerticalAlignment="Bottom"
-                        Orientation="Horizontal">
-                    <Button Width="140"
-                        x:Name="uiPageBtnLink"
-                        Click="PageBtnLink_Click"
-                        ToolTipService.ToolTip="Link or unlink this system to/from another configuration">
-                        <StackPanel Orientation="Horizontal">
-                            <FontIcon Margin="0,0,6,0"
-                                  FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE71B;"/>
-                            <TextBlock VerticalAlignment="center"
-                                   x:Name="uiPageBtnTxtLink">
-                            FIXUP
-                            </TextBlock>
-                        </StackPanel>
-                    </Button>
-                    <TextBlock Margin="12,0,24,0"
-                           x:Name="uiPageTxtLink"
-                           VerticalAlignment="center">
-                    FIXUP
-                    </TextBlock>
-                </StackPanel>
-
-                <StackPanel Grid.Column="1"
-                        VerticalAlignment="Bottom"
-                        Orientation="Horizontal">
-                    <Button x:Name="uiPageBtnReset"
-                        Click="PageBtnReset_Click"
-                        ToolTipService.ToolTip="Reset the configuration of this system to its defaults">
-                        <StackPanel Orientation="Horizontal">
-                            <FontIcon Margin="0,0,6,0"
-                                  FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE894;"/>
-                            <TextBlock VerticalAlignment="center">Reset Page to Defaults</TextBlock>
-                        </StackPanel>
-                    </Button>
-                </StackPanel>
-            </Grid>
         </Grid>
     </NavigationView>
-</Page>
+</local:A10CPageBase>

--- a/JAFDTC/UI/A10C/A10CEditDSMSPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditDSMSPage.xaml.cs
@@ -28,11 +28,6 @@ using JAFDTC.Models;
 
 namespace JAFDTC.UI.A10C
 {
-    public interface IA10CDSMSContentFrame
-    {
-        void CopyConfigToEditState();
-    }
-
     /// <summary>
     /// Code-behind class for the A10 DSMS editor.
     /// </summary>
@@ -40,12 +35,14 @@ namespace JAFDTC.UI.A10C
     {
         internal class DSMSEditorNavArgs
         {
-            internal ConfigEditorPageNavArgs NavArgs { get; }
+            internal NavigationEventArgs BaseArgs { get; }
+            internal ConfigEditorPageNavArgs EditorPageNavArgs { get; }
             internal A10CEditDSMSPage ParentPage { get; }
 
-            internal DSMSEditorNavArgs(ConfigEditorPageNavArgs navArgs, A10CEditDSMSPage parentPage)
+            internal DSMSEditorNavArgs(NavigationEventArgs args, A10CEditDSMSPage parentPage)
             {
-                NavArgs = navArgs;
+                BaseArgs = args;
+                EditorPageNavArgs = (ConfigEditorPageNavArgs)args.Parameter;
                 ParentPage = parentPage;
             }
         }
@@ -67,14 +64,14 @@ namespace JAFDTC.UI.A10C
 
         // ---- UI helpers -----------------------------------------------------------------------------------------
 
-        protected override void CopyConfigToEditState()
+        public override void CopyConfigToEditState()
         {
             if (DSMSContentFrame.Content != null)
-                ((IA10CDSMSContentFrame)DSMSContentFrame.Content).CopyConfigToEditState();
+                ((A10CPageBase)DSMSContentFrame.Content).CopyConfigToEditState();
             UpdateDefaultStateIndicators();
         }
 
-        private void UpdateDefaultStateIndicators() 
+        private void UpdateDefaultStateIndicators()
         {
             bool munitionsTabIsDefault = _config.DSMS.IsLaserCodeDefault && _config.DSMS.AreAllMunitionSettingsDefault;
             if (munitionsTabIsDefault)
@@ -88,12 +85,6 @@ namespace JAFDTC.UI.A10C
                 uiIconProfileTab.Visibility = Visibility.Visible;
 
             uiCtlLinkResetBtns.SetResetButtonEnabled(!munitionsTabIsDefault || !_config.DSMS.IsProfileOrderDefault);
-        }
-
-        private void LinkResetChangeHandler()
-        {
-            ((IA10CDSMSContentFrame)DSMSContentFrame.Content).CopyConfigToEditState();
-            UpdateDefaultStateIndicators();
         }
 
         private void ConfigurationSavedHandler(object sender, ConfigurationSavedEventArgs args)
@@ -117,8 +108,7 @@ namespace JAFDTC.UI.A10C
         {
             base.OnNavigatedTo(args);
          
-            _dsmsEditorNavArgs = new DSMSEditorNavArgs(_navArgs, this);
-            uiCtlLinkResetBtns.ConfigLinkedOrReset += LinkResetChangeHandler;
+            _dsmsEditorNavArgs = new DSMSEditorNavArgs(args, this);
 
             _config.ConfigurationSaved += ConfigurationSavedHandler;
             UpdateDefaultStateIndicators();
@@ -126,7 +116,6 @@ namespace JAFDTC.UI.A10C
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
-            uiCtlLinkResetBtns.ConfigLinkedOrReset -= LinkResetChangeHandler;
             _config.ConfigurationSaved -= ConfigurationSavedHandler;
 
             base.OnNavigatedFrom(e);

--- a/JAFDTC/UI/A10C/A10CEditDSMSProfileOrder.xaml
+++ b/JAFDTC/UI/A10C/A10CEditDSMSProfileOrder.xaml
@@ -18,11 +18,12 @@ https://www.gnu.org/licenses/.
 
 **********************************************************************************************************************
 -->
-<Page
+<ui:A10CPageBase
     x:Class="JAFDTC.UI.A10C.A10CEditDSMSProfileOrderPage"
+    xmlns:ui="using:JAFDTC.UI.A10C"
+    xmlns:models="using:JAFDTC.Models.A10C"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:JAFDTC.Models.A10C"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
@@ -41,7 +42,7 @@ https://www.gnu.org/licenses/.
                   ItemsSource="{x:Bind _munitions}" CanDragItems="True" Width="175"
             SelectionMode="None" AllowDrop="True" CanReorderItems="True" DragItemsCompleted="uiListProfiles_DragItemsCompleted">
             <ListView.ItemTemplate>
-                <DataTemplate x:DataType="local:A10CMunition">
+                <DataTemplate x:DataType="models:A10CMunition">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="20"/> <!-- Always empty here, but matching the layout on the munition settings tab. -->
@@ -64,4 +65,4 @@ https://www.gnu.org/licenses/.
             Drag to adjust the order of default weapon profiles in the jet.
         </TextBlock>
     </Grid>
-</Page>
+</ui:A10CPageBase>

--- a/JAFDTC/UI/A10C/A10CEditDSMSProfileOrder.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditDSMSProfileOrder.xaml.cs
@@ -18,6 +18,7 @@
 // ********************************************************************************************************************
 
 using JAFDTC.Models.A10C;
+using JAFDTC.Models.A10C.DSMS;
 using JAFDTC.UI.App;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
@@ -31,23 +32,24 @@ namespace JAFDTC.UI.A10C
     /// <summary>
     /// Content pane for setting A-10 default weapon profile order.
     /// </summary>
-    public sealed partial class A10CEditDSMSProfileOrderPage : Page, IA10CDSMSContentFrame
+    public sealed partial class A10CEditDSMSProfileOrderPage : A10CPageBase
     {
-        private DSMSEditorNavArgs _dsmsEditorNavArgs;
-        private A10CConfiguration _config;
+        private const string SYSTEM_NAME = "DSMS";
 
+        public override A10CSystemBase SystemConfig => _config.DSMS;
+
+        private DSMSEditorNavArgs _dsmsEditorNavArgs;
         private ObservableCollection<A10CMunition> _munitions;
 
-        private bool _suspendUIUpdates = false;
-
-        public A10CEditDSMSProfileOrderPage()
+        public A10CEditDSMSProfileOrderPage() : base(SYSTEM_NAME, DSMSSystem.SystemTag)
         {
             _munitions = new ObservableCollection<A10CMunition>(A10CMunition.GetUniqueProfileMunitions());
 
             InitializeComponent();
+            InitializeBase(new DSMSSystem());
         }
 
-        private void SaveEditStateToConfig()
+        protected override void SaveEditStateToConfig()
         {
             List<int> newOrder = new List<int>(_munitions.Count);
             foreach (A10CMunition m in _munitions)
@@ -56,11 +58,8 @@ namespace JAFDTC.UI.A10C
             _config.Save(_dsmsEditorNavArgs.ParentPage, SystemTag);
         }
 
-        public void CopyConfigToEditState()
+        public override void CopyConfigToEditState()
         {
-            if (_suspendUIUpdates)
-                return;
-
             if (_config.DSMS.ProfileOrder == null)
             {
                 _munitions = new ObservableCollection<A10CMunition>(A10CMunition.GetUniqueProfileMunitions());
@@ -86,24 +85,13 @@ namespace JAFDTC.UI.A10C
 
         private void uiListProfiles_DragItemsCompleted(ListViewBase sender, DragItemsCompletedEventArgs args)
         {
-            _suspendUIUpdates = true;
             SaveEditStateToConfig();
-            _suspendUIUpdates = false;
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs args)
         {
             _dsmsEditorNavArgs = (DSMSEditorNavArgs)args.Parameter;
-            _config = (A10CConfiguration)_dsmsEditorNavArgs.NavArgs.Config;
-
-            CopyConfigToEditState();
-
-            base.OnNavigatedTo(args);
-        }
-
-        protected override void OnNavigatedFrom(NavigationEventArgs e)
-        {
-            base.OnNavigatedFrom(e);
+            base.OnNavigatedTo(_dsmsEditorNavArgs.BaseArgs);
         }
     }
 }

--- a/JAFDTC/UI/A10C/A10CEditHMCSPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditHMCSPage.xaml
@@ -102,6 +102,7 @@ https://www.gnu.org/licenses/.
                         <FontIcon Grid.Column="0"
                                   x:Name="uiProfile1SelectIcon"
                                   VerticalAlignment="Center"
+                                  Visibility="Collapsed"
                                   Foreground="{ThemeResource SystemAccentColor}"
                                   FontFamily="Segoe Fluent Icons" Glyph="&#xE915;"/>
                         <TextBlock Grid.Column="1" Margin="8,0,0,0"
@@ -117,6 +118,7 @@ https://www.gnu.org/licenses/.
                         <FontIcon Grid.Column="0"
                                   x:Name="uiProfile2SelectIcon"
                                   VerticalAlignment="Center"
+                                  Visibility="Collapsed"
                                   Foreground="{ThemeResource SystemAccentColor}"
                                   FontFamily="Segoe Fluent Icons" Glyph="&#xE915;"/>
                         <TextBlock Grid.Column="1" Margin="8,0,0,0"
@@ -132,6 +134,7 @@ https://www.gnu.org/licenses/.
                         <FontIcon Grid.Column="0"
                                   x:Name="uiProfile3SelectIcon"
                                   VerticalAlignment="Center"
+                                  Visibility="Collapsed"
                                   Foreground="{ThemeResource SystemAccentColor}"
                                   FontFamily="Segoe Fluent Icons" Glyph="&#xE915;"/>
                         <TextBlock Grid.Column="1" Margin="8,0,0,0"

--- a/JAFDTC/UI/A10C/A10CEditHMCSPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditHMCSPage.xaml
@@ -20,9 +20,10 @@ https://www.gnu.org/licenses/.
 -->
 <local:A10CPageBase
     x:Class="JAFDTC.UI.A10C.A10CEditHMCSPage"
+    xmlns:local="using:JAFDTC.UI.A10C"
+    xmlns:controls="using:JAFDTC.UI.Controls"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:JAFDTC.UI.A10C"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
@@ -495,48 +496,7 @@ https://www.gnu.org/licenses/.
         row 4: link / reset
         ===============================================================================================================
         -->
-        <Grid Grid.Row="4" Margin="12,12,12,12">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
+        <controls:LinkResetBtnsControl x:Name="uiCtlLinkResetBtns" Grid.Row="4"/>
 
-            <StackPanel Grid.Column="0"
-                        VerticalAlignment="Bottom"
-                        Orientation="Horizontal">
-                <Button Width="140"
-                        x:Name="uiPageBtnLink"
-                        Click="PageBtnLink_Click"
-                        ToolTipService.ToolTip="Link or unlink this system to/from another configuration">
-                    <StackPanel Orientation="Horizontal">
-                        <FontIcon Margin="0,0,6,0"
-                                  FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE71B;"/>
-                        <TextBlock VerticalAlignment="center"
-                                   x:Name="uiPageBtnTxtLink">
-                            FIXUP
-                        </TextBlock>
-                    </StackPanel>
-                </Button>
-                <TextBlock Margin="12,0,24,0"
-                           x:Name="uiPageTxtLink"
-                           VerticalAlignment="center">
-                    FIXUP
-                </TextBlock>
-            </StackPanel>
-
-            <StackPanel Grid.Column="1"
-                        VerticalAlignment="Bottom"
-                        Orientation="Horizontal">
-                <Button x:Name="uiPageBtnReset"
-                        Click="PageBtnReset_Click"
-                        ToolTipService.ToolTip="Reset the configuration of this system to its defaults">
-                    <StackPanel Orientation="Horizontal">
-                        <FontIcon Margin="0,0,6,0"
-                                  FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE894;"/>
-                        <TextBlock VerticalAlignment="center">Reset Page to Defaults</TextBlock>
-                    </StackPanel>
-                </Button>
-            </StackPanel>
-        </Grid>
     </Grid>
 </local:A10CPageBase>

--- a/JAFDTC/UI/A10C/A10CEditHMCSPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditHMCSPage.xaml.cs
@@ -38,7 +38,7 @@ namespace JAFDTC.UI.A10C
         private const string SYSTEM_NAME = "HMCS";
 
         private HMCSSystem EditState => (HMCSSystem)_editState;
-        protected override A10CSystemBase SystemConfig => _config.HMCS;
+        public override A10CSystemBase SystemConfig => _config.HMCS;
 
         public static ConfigEditorPageInfo PageInfo
             => new(HMCSSystem.SystemTag, SYSTEM_NAME, SYSTEM_NAME, Glyphs.HMCS, typeof(A10CEditHMCSPage));
@@ -46,7 +46,7 @@ namespace JAFDTC.UI.A10C
         public A10CEditHMCSPage() : base(SYSTEM_NAME, HMCSSystem.SystemTag)
         {
             InitializeComponent();
-            InitializeBase(new HMCSSystem(), uiTextFlightMembers, uiPageBtnTxtLink, uiPageTxtLink, uiPageBtnReset);
+            InitializeBase(new HMCSSystem(), uiTextFlightMembers, uiCtlLinkResetBtns);
         }
 
         // ---- UI helpers  -------------------------------------------------------------------------------------------
@@ -186,7 +186,6 @@ namespace JAFDTC.UI.A10C
                 if (oldSettings != null)
                 {
                     oldSettings.ErrorsChanged -= BaseField_DataValidationError;
-                    oldSettings.PropertyChanged -= BaseField_PropertyChanged;
                     
                     // BindableObject remembers errors but not the value that caused them. So changing this
                     // back to a profile with an error, you get a red box on a good value. Clearing the error
@@ -201,7 +200,6 @@ namespace JAFDTC.UI.A10C
                 if (newSettings != null)
                 {
                     newSettings.ErrorsChanged += BaseField_DataValidationError;
-                    newSettings.PropertyChanged += BaseField_PropertyChanged;
 
                     CopyConfigToEditState(newSettings);
                     UpdateUIFromEditState();

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
@@ -20,9 +20,10 @@ https://www.gnu.org/licenses/.
 -->
 <local:A10CPageBase
     x:Class="JAFDTC.UI.A10C.A10CEditMiscPage"
+    xmlns:local="using:JAFDTC.UI.A10C"
+    xmlns:controls="using:JAFDTC.UI.Controls"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:JAFDTC.UI.A10C"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
@@ -421,49 +422,7 @@ https://www.gnu.org/licenses/.
         link / reset
         ===============================================================================================================
         -->
-        <Grid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="12,12,12,12">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-
-            <StackPanel Grid.Column="0"
-                        VerticalAlignment="Bottom"
-                        Orientation="Horizontal">
-                <Button Width="140"
-                        x:Name="uiPageBtnLink"
-                        Click="PageBtnLink_Click"
-                        ToolTipService.ToolTip="Link or unlink this system to/from another configuration">
-                    <StackPanel Orientation="Horizontal">
-                        <FontIcon Margin="0,0,6,0"
-                                  FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE71B;"/>
-                        <TextBlock VerticalAlignment="center"
-                                   x:Name="uiPageBtnTxtLink">
-                            FIXUP
-                        </TextBlock>
-                    </StackPanel>
-                </Button>
-                <TextBlock Margin="12,0,24,0"
-                           x:Name="uiPageTxtLink"
-                           VerticalAlignment="center">
-                    FIXUP
-                </TextBlock>
-            </StackPanel>
-
-            <StackPanel Grid.Column="1"
-                        VerticalAlignment="Bottom"
-                        Orientation="Horizontal">
-                <Button x:Name="uiPageBtnReset"
-                        Click="PageBtnReset_Click"
-                        ToolTipService.ToolTip="Reset the configuration of this system to its defaults">
-                    <StackPanel Orientation="Horizontal">
-                        <FontIcon Margin="0,0,6,0"
-                                  FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE894;"/>
-                        <TextBlock VerticalAlignment="center">Reset Page to Defaults</TextBlock>
-                    </StackPanel>
-                </Button>
-            </StackPanel>
-        </Grid>
+        <controls:LinkResetBtnsControl x:Name="uiCtlLinkResetBtns" Grid.Row="2" Grid.ColumnSpan="3"/>
 
     </Grid>
 </local:A10CPageBase>

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml.cs
@@ -30,7 +30,7 @@ namespace JAFDTC.UI.A10C
     {
         private const string SYSTEM_NAME = "Miscellaneous";
 
-        protected override A10CSystemBase SystemConfig => _config.Misc;
+        public override A10CSystemBase SystemConfig => _config.Misc;
 
         public static ConfigEditorPageInfo PageInfo
             => new(MiscSystem.SystemTag, SYSTEM_NAME, SYSTEM_NAME, Glyphs.MISC, typeof(A10CEditMiscPage));
@@ -38,7 +38,7 @@ namespace JAFDTC.UI.A10C
         public A10CEditMiscPage() : base(SYSTEM_NAME, MiscSystem.SystemTag)
         {
             InitializeComponent();
-            InitializeBase(new MiscSystem(), uiTextTACANChannel, uiPageBtnTxtLink, uiPageTxtLink, uiPageBtnReset);
+            InitializeBase(new MiscSystem(), uiTextTACANChannel, uiCtlLinkResetBtns);
         }
     }
 }

--- a/JAFDTC/UI/A10C/A10CEditTADPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditTADPage.xaml
@@ -20,9 +20,10 @@ https://www.gnu.org/licenses/.
 -->
 <local:A10CPageBase
     x:Class="JAFDTC.UI.A10C.A10CEditTADPage"
+    xmlns:local="using:JAFDTC.UI.A10C"
+    xmlns:controls="using:JAFDTC.UI.Controls"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:JAFDTC.UI.A10C"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
@@ -401,48 +402,7 @@ https://www.gnu.org/licenses/.
         ===============================================================================================================
         -->
 
-        <Grid Grid.Row="1" Margin="12,12,12,12">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
+        <controls:LinkResetBtnsControl x:Name="uiCtlLinkResetBtns" Grid.Row="1"/>
 
-            <StackPanel Grid.Column="0"
-                        VerticalAlignment="Bottom"
-                        Orientation="Horizontal">
-                <Button Width="140"
-                        x:Name="uiPageBtnLink"
-                        Click="PageBtnLink_Click"
-                        ToolTipService.ToolTip="Link or unlink this system to/from another configuration">
-                    <StackPanel Orientation="Horizontal">
-                        <FontIcon Margin="0,0,6,0"
-                                  FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE71B;"/>
-                        <TextBlock VerticalAlignment="center"
-                                   x:Name="uiPageBtnTxtLink">
-                            FIXUP
-                        </TextBlock>
-                    </StackPanel>
-                </Button>
-                <TextBlock Margin="12,0,24,0"
-                           x:Name="uiPageTxtLink"
-                           VerticalAlignment="center">
-                    FIXUP
-                </TextBlock>
-            </StackPanel>
-
-            <StackPanel Grid.Column="1"
-                        VerticalAlignment="Bottom"
-                        Orientation="Horizontal">
-                <Button x:Name="uiPageBtnReset"
-                        Click="PageBtnReset_Click"
-                        ToolTipService.ToolTip="Reset the configuration of this system to its defaults">
-                    <StackPanel Orientation="Horizontal">
-                        <FontIcon Margin="0,0,6,0"
-                                  FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE894;"/>
-                        <TextBlock VerticalAlignment="center">Reset Page to Defaults</TextBlock>
-                    </StackPanel>
-                </Button>
-            </StackPanel>
-        </Grid>
     </Grid>
 </local:A10CPageBase>

--- a/JAFDTC/UI/A10C/A10CEditTADPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditTADPage.xaml.cs
@@ -30,7 +30,7 @@ namespace JAFDTC.UI.A10C
     {
         private const string SYSTEM_NAME = "TAD";
 
-        protected override A10CSystemBase SystemConfig => _config.TAD;
+        public override A10CSystemBase SystemConfig => _config.TAD;
 
         public static ConfigEditorPageInfo PageInfo
             => new(TADSystem.SystemTag, SYSTEM_NAME, SYSTEM_NAME, Glyphs.TAD, typeof(A10CEditTADPage));
@@ -38,7 +38,7 @@ namespace JAFDTC.UI.A10C
         public A10CEditTADPage() : base(SYSTEM_NAME, TADSystem.SystemTag)
         {
             InitializeComponent();
-            InitializeBase(new TADSystem(), uiTextGroupID, uiPageBtnTxtLink, uiPageTxtLink, uiPageBtnReset);
+            InitializeBase(new TADSystem(), uiTextGroupID, uiCtlLinkResetBtns);
         }
     }
 }

--- a/JAFDTC/UI/A10C/A10CEditTGPPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditTGPPage.xaml
@@ -20,9 +20,10 @@ https://www.gnu.org/licenses/.
 -->
 <local:A10CPageBase
     x:Class="JAFDTC.UI.A10C.A10CEditTGPPage"
+    xmlns:local="using:JAFDTC.UI.A10C"
+    xmlns:controls="using:JAFDTC.UI.Controls"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:JAFDTC.UI.A10C"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
@@ -208,49 +209,7 @@ https://www.gnu.org/licenses/.
         row 1: link / reset
         ===============================================================================================================
         -->
-        
-        <Grid Grid.Row="1" Margin="12,12,12,12">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
+        <controls:LinkResetBtnsControl x:Name="uiCtlLinkResetBtns" Grid.Row="1"/>
 
-            <StackPanel Grid.Column="0"
-                        VerticalAlignment="Bottom"
-                        Orientation="Horizontal">
-                <Button Width="140"
-                        x:Name="uiPageBtnLink"
-                        Click="PageBtnLink_Click"
-                        ToolTipService.ToolTip="Link or unlink this system to/from another configuration">
-                    <StackPanel Orientation="Horizontal">
-                        <FontIcon Margin="0,0,6,0"
-                                  FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE71B;"/>
-                        <TextBlock VerticalAlignment="center"
-                                   x:Name="uiPageBtnTxtLink">
-                            FIXUP
-                        </TextBlock>
-                    </StackPanel>
-                </Button>
-                <TextBlock Margin="12,0,24,0"
-                           x:Name="uiPageTxtLink"
-                           VerticalAlignment="center">
-                    FIXUP
-                </TextBlock>
-            </StackPanel>
-
-            <StackPanel Grid.Column="1"
-                        VerticalAlignment="Bottom"
-                        Orientation="Horizontal">
-                <Button x:Name="uiPageBtnReset"
-                        Click="PageBtnReset_Click"
-                        ToolTipService.ToolTip="Reset the configuration of this system to its defaults">
-                    <StackPanel Orientation="Horizontal">
-                        <FontIcon Margin="0,0,6,0"
-                                  FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE894;"/>
-                        <TextBlock VerticalAlignment="center">Reset Page to Defaults</TextBlock>
-                    </StackPanel>
-                </Button>
-            </StackPanel>
-        </Grid>
     </Grid>
 </local:A10CPageBase>

--- a/JAFDTC/UI/A10C/A10CEditTGPPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditTGPPage.xaml.cs
@@ -30,7 +30,7 @@ namespace JAFDTC.UI.A10C
     {
         private const string SYSTEM_NAME = "TGP";
 
-        protected override A10CSystemBase SystemConfig => _config.TGP;
+        public override A10CSystemBase SystemConfig => _config.TGP;
 
         public static ConfigEditorPageInfo PageInfo
             => new(TGPSystem.SystemTag, SYSTEM_NAME, SYSTEM_NAME, Glyphs.TGP, typeof(A10CEditTGPPage));
@@ -38,8 +38,7 @@ namespace JAFDTC.UI.A10C
         public A10CEditTGPPage() : base(SYSTEM_NAME, TGPSystem.SystemTag)
         {
             InitializeComponent();
-            InitializeBase(new TGPSystem(), uiTextLaserCode, uiPageBtnTxtLink, uiPageTxtLink, uiPageBtnReset);
+            InitializeBase(new TGPSystem(), uiTextLaserCode, uiCtlLinkResetBtns);
         }
-
     }
 }

--- a/JAFDTC/UI/Controls/LinkResetBtnsControl.xaml
+++ b/JAFDTC/UI/Controls/LinkResetBtnsControl.xaml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="JAFDTC.UI.Controls.LinkResetBtnsControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid Margin="12,12,12,12">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+
+        <StackPanel Grid.Column="0"
+                        VerticalAlignment="Bottom"
+                        Orientation="Horizontal">
+            <Button Width="140"
+                        x:Name="uiPageBtnLink"
+                        Click="PageBtnLink_Click"
+                        ToolTipService.ToolTip="Link or unlink this system to/from another configuration">
+                <StackPanel Orientation="Horizontal">
+                    <FontIcon Margin="0,0,6,0"
+                                  FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE71B;"/>
+                    <TextBlock VerticalAlignment="center"
+                                   x:Name="uiPageBtnTxtLink">
+                            FIXUP
+                    </TextBlock>
+                </StackPanel>
+            </Button>
+            <TextBlock Margin="12,0,24,0"
+                           x:Name="uiPageTxtLink"
+                           VerticalAlignment="center">
+                    FIXUP
+            </TextBlock>
+        </StackPanel>
+
+        <StackPanel Grid.Column="1"
+                        VerticalAlignment="Bottom"
+                        Orientation="Horizontal">
+            <Button x:Name="uiPageBtnReset"
+                        Click="PageBtnReset_Click"
+                        ToolTipService.ToolTip="Reset the configuration of this system to its defaults">
+                <StackPanel Orientation="Horizontal">
+                    <FontIcon Margin="0,0,6,0"
+                                  FontFamily="Segoe Fluent Icons" FontSize="14" Glyph="&#xE894;"/>
+                    <TextBlock VerticalAlignment="center">Reset Page to Defaults</TextBlock>
+                </StackPanel>
+            </Button>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/JAFDTC/UI/Controls/LinkResetBtnsControl.xaml.cs
+++ b/JAFDTC/UI/Controls/LinkResetBtnsControl.xaml.cs
@@ -1,0 +1,97 @@
+using CommunityToolkit.WinUI.UI;
+using JAFDTC.Models;
+using JAFDTC.Models.A10C;
+using JAFDTC.UI.A10C;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System;
+using System.Collections.Generic;
+
+namespace JAFDTC.UI.Controls
+{
+    public sealed partial class LinkResetBtnsControl : UserControl
+    {
+        private A10CPageBase _parentPage;
+        private A10CConfiguration _config;
+
+        private string _systemTag;
+
+        // For the configuration linking UI.
+        private readonly Dictionary<string, string> _systemConfigNameToUID = new Dictionary<string, string>();
+        private readonly List<string> _systemConfigNameList = new List<string>();
+        private string _systemName;
+        private Dictionary<string, IConfiguration> _uidToConfigMap;
+
+        public event Action ConfigChanged;
+        private void OnConfigChanged()
+        {
+            ConfigChanged?.Invoke();
+        }
+
+        public LinkResetBtnsControl()
+        {
+            InitializeComponent();
+        }
+
+        public void Initialize(string systemName, string systemTag, A10CPageBase parentPage, A10CConfiguration config)
+        {
+            _config = config;
+            _parentPage = parentPage;
+            _systemName = systemName;
+            _systemTag = systemTag;
+        }
+
+        public void NavigatedTo(Dictionary<string, IConfiguration> uidToConfigMap)
+        {
+            _uidToConfigMap = uidToConfigMap;
+            Utilities.BuildSystemLinkLists(uidToConfigMap, _config.UID, _systemTag, _systemConfigNameList, _systemConfigNameToUID);
+            UpdateLinkControls();
+        }
+
+        public void SetResetButtonEnabled(bool enabled)
+        {
+            uiPageBtnReset.IsEnabled = enabled;
+        }
+
+        private void UpdateLinkControls()
+        {
+            Utilities.RebuildLinkControls(_config, _systemTag, _uidToConfigMap, uiPageBtnTxtLink, uiPageTxtLink);
+        }
+
+        private async void PageBtnReset_Click(object sender, RoutedEventArgs e)
+        {
+            ContentDialogResult result = await Utilities.Message2BDialog(
+                Content.XamlRoot,
+                "Reset Configuration?",
+                "Are you sure you want to reset the " + _systemName + " configurations to avionics defaults? This action cannot be undone.",
+                "Reset"
+            );
+            if (result == ContentDialogResult.Primary)
+            {
+                _config.UnlinkSystem(_systemTag);
+                UpdateLinkControls();
+                _parentPage.SystemConfig.Reset();
+                _config.Save(_parentPage, _systemTag);
+                OnConfigChanged();
+            }
+        }
+
+        private async void PageBtnLink_Click(object sender, RoutedEventArgs args)
+        {
+            string selectedItem = await Utilities.PageBtnLink_Click(Content.XamlRoot, _config, _systemTag, _systemConfigNameList);
+            if (selectedItem == null)
+            {
+                _config.UnlinkSystem(_systemTag);
+                _config.Save(_parentPage);
+            }
+            else if (selectedItem.Length > 0)
+            {
+                 _config.LinkSystemTo(_systemTag, _uidToConfigMap[_systemConfigNameToUID[selectedItem]]);
+                _config.Save(_parentPage);
+            }
+
+            OnConfigChanged();
+            UpdateLinkControls();
+        }
+    }
+}

--- a/JAFDTC/UI/Controls/LinkResetBtnsControl.xaml.cs
+++ b/JAFDTC/UI/Controls/LinkResetBtnsControl.xaml.cs
@@ -22,10 +22,10 @@ namespace JAFDTC.UI.Controls
         private string _systemName;
         private Dictionary<string, IConfiguration> _uidToConfigMap;
 
-        public event Action ConfigChanged;
-        private void OnConfigChanged()
+        public event Action ConfigLinkedOrReset;
+        private void OnConfigLinkedOrReset()
         {
-            ConfigChanged?.Invoke();
+            ConfigLinkedOrReset?.Invoke();
         }
 
         public LinkResetBtnsControl()
@@ -58,7 +58,7 @@ namespace JAFDTC.UI.Controls
             Utilities.RebuildLinkControls(_config, _systemTag, _uidToConfigMap, uiPageBtnTxtLink, uiPageTxtLink);
         }
 
-        private async void PageBtnReset_Click(object sender, RoutedEventArgs e)
+        private async void PageBtnReset_Click(object _, RoutedEventArgs __)
         {
             ContentDialogResult result = await Utilities.Message2BDialog(
                 Content.XamlRoot,
@@ -72,7 +72,7 @@ namespace JAFDTC.UI.Controls
                 UpdateLinkControls();
                 _parentPage.SystemConfig.Reset();
                 _config.Save(_parentPage, _systemTag);
-                OnConfigChanged();
+                OnConfigLinkedOrReset();
             }
         }
 
@@ -90,7 +90,7 @@ namespace JAFDTC.UI.Controls
                 _config.Save(_parentPage);
             }
 
-            OnConfigChanged();
+            OnConfigLinkedOrReset();
             UpdateLinkControls();
         }
     }


### PR DESCRIPTION
Converted all the A-10 system editors to use A10PageBase. Introduced LinkRestBtnsControl to make dropping those on every new page easier.

Very few user-visible changes, but cleaned up tons of funky UI logic. There were all kinds of spurious UI updates and config file saves that have been eliminated. Handling of invalid text input was also substantially improved. Getting all the fiddly little UI edge cases right is tricky, which makes me think this common base page approach is all the wiser.

I'll look to consolidate with @ilominar's base page once we're coexisting on main.
