### PR TITLE
A-10C IFFCC System Editor, various fixes

### DIFF
--- a/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
+++ b/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
@@ -131,6 +131,10 @@ function JAFDTC_A10C_GetCDU_value(key)
     return value;
 end
 
+function JAFDTC_A10C_Fn_IsWyptElevationDifferent(set_elevation)
+    return tonumber(set_elevation) ~= tonumber(JAFDTC_A10C_GetCDU_value("WAYPT_EL3"));
+end
+
 function JAFDTC_A10C_Fn_IsCoordFmtLL()
     local value = JAFDTC_A10C_GetCDU_value("WAYPTCoordFormat");
     return string.sub(value, 1, 3) == "L/L"

--- a/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
+++ b/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
@@ -156,14 +156,9 @@ function JAFDTC_A10C_Fn_IsFlightPlanNotManual()
     return false
 end
 
-function JAFDTC_A10C_Fn_SpeedIsAvailable()
+function JAFDTC_A10C_Fn_IsSpeedAvailable()
     local table = JAFDTC_A10C_GetCDU();
     return table["STRSpeedMode4"] == "IAS" or table["STRSpeedMode5"] == "TAS" or table["STRSpeedMode6"] == "GS"
-end
-
-function JAFDTC_A10C_Fn_SpeedIsNotAvailable()
-    local table = JAFDTC_A10C_GetCDU();
-    return table["STRSpeedMode4"] ~= "IAS" and table["STRSpeedMode5"] ~= "TAS" and table["STRSpeedMode6"] ~= "GS"
 end
 
 function JAFDTC_A10C_Fn_SpeedIsNot(speed)

--- a/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
+++ b/JAFDTC/DCS/JAFDTC/A10CFunctions.lua
@@ -113,6 +113,11 @@ end
 
 -- CDU Routines
 
+function JAFDTC_A10C_Fn_IsCDUInDefaultMFDPosition()
+    local value = JAFDTC_A10C_GetRMFD_value("label_12");
+    return value == "CDU";
+end
+
 function JAFDTC_A10C_GetCDU()
     local table = JAFDTC_ParseDisplay(3);
     JAFDTC_DebugDisplay(table);
@@ -128,18 +133,7 @@ end
 
 function JAFDTC_A10C_Fn_IsCoordFmtLL()
     local value = JAFDTC_A10C_GetCDU_value("WAYPTCoordFormat");
-    if string.sub(value, 1, 3) == "L/L" then
-        return true
-    end
-    return false
-end
-
-function JAFDTC_A10C_Fn_IsCoordFmtNotLL()
-    local value = JAFDTC_A10C_GetCDU_value("WAYPTCoordFormat");
-    if string.sub(value, 1, 3) ~= "L/L" then
-        return true
-    end
-    return false
+    return string.sub(value, 1, 3) == "L/L"
 end
 
 function JAFDTC_A10C_Fn_IsBullsNotOnHUD()

--- a/JAFDTC/JAFDTC.csproj
+++ b/JAFDTC/JAFDTC.csproj
@@ -53,6 +53,7 @@
     <None Remove="UI\A10C\A10CEditDSMSMunitionSettingsPage.xaml" />
     <None Remove="UI\A10C\A10CEditDSMSProfileOrder.xaml" />
     <None Remove="UI\A10C\A10CEditHMCSPage.xaml" />
+    <None Remove="UI\A10C\A10CEditIFFCCPage.xaml" />
     <None Remove="UI\A10C\A10CEditMiscPage.xaml" />
     <None Remove="UI\A10C\A10CEditTADPage.xaml" />
     <None Remove="UI\A10C\A10CEditTGPPage.xaml" />
@@ -315,5 +316,13 @@
     <Page Update="UI\Base\EditNavpointListPage.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
+  </ItemGroup>
+
+  <ItemGroup>
+    <CustomAdditionalCompileInputs Remove="UI\A10C\A10CEditIFFCCPage.xaml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Resource Remove="UI\A10C\A10CEditIFFCCPage.xaml" />
   </ItemGroup>
 </Project>

--- a/JAFDTC/Models/A10C/A10CConfiguration.cs
+++ b/JAFDTC/Models/A10C/A10CConfiguration.cs
@@ -30,6 +30,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Text.Json;
+using JAFDTC.Models.A10C.IFFCC;
 
 namespace JAFDTC.Models.A10C
 {
@@ -52,8 +53,10 @@ namespace JAFDTC.Models.A10C
 
         public HMCSSystem HMCS { get; set; }
 
+        public IFFCCSystem IFFCC { get; set; }
+
         public MiscSystem Misc { get; set; }
-        
+
         public RadioSystem Radio { get; set; }
 
         public TADSystem TAD { get; set; }
@@ -76,6 +79,7 @@ namespace JAFDTC.Models.A10C
         {
             DSMS = new DSMSSystem();
             HMCS = new HMCSSystem();
+            IFFCC = new IFFCCSystem();
             Misc = new MiscSystem();
             Radio = new RadioSystem();
             TAD = new TADSystem();
@@ -95,6 +99,7 @@ namespace JAFDTC.Models.A10C
             {
                 DSMS = (DSMSSystem)DSMS.Clone(),
                 HMCS = (HMCSSystem)HMCS.Clone(),
+                IFFCC = (IFFCCSystem)IFFCC.Clone(),
                 Misc = (MiscSystem)Misc.Clone(),
                 Radio = (RadioSystem)Radio.Clone(),
                 TAD = (TADSystem)TAD.Clone(),
@@ -112,6 +117,7 @@ namespace JAFDTC.Models.A10C
             {
                 case DSMSSystem.SystemTag: DSMS = (DSMSSystem)otherHawg.DSMS.Clone(); break;
                 case HMCSSystem.SystemTag: HMCS = (HMCSSystem)otherHawg.HMCS.Clone(); break;
+                case IFFCCSystem.SystemTag: IFFCC = (IFFCCSystem)otherHawg.IFFCC.Clone(); break;
                 case MiscSystem.SystemTag: Misc = (MiscSystem)otherHawg.Misc.Clone(); break;
                 case RadioSystem.SystemTag: Radio = (RadioSystem)otherHawg.Radio.Clone(); break;
                 case TADSystem.SystemTag: TAD = (TADSystem)otherHawg.TAD.Clone(); break;
@@ -149,6 +155,7 @@ namespace JAFDTC.Models.A10C
                 null => JsonSerializer.Serialize(this, Configuration.JsonOptions),
                 DSMSSystem.SystemTag => JsonSerializer.Serialize(DSMS, Configuration.JsonOptions),
                 HMCSSystem.SystemTag => JsonSerializer.Serialize(HMCS, Configuration.JsonOptions),
+                IFFCCSystem.SystemTag => JsonSerializer.Serialize(IFFCC, Configuration.JsonOptions),
                 MiscSystem.SystemTag => JsonSerializer.Serialize(Misc, Configuration.JsonOptions),
                 RadioSystem.SystemTag => JsonSerializer.Serialize(Radio, Configuration.JsonOptions),
                 TADSystem.SystemTag => JsonSerializer.Serialize(TAD, Configuration.JsonOptions),
@@ -162,6 +169,7 @@ namespace JAFDTC.Models.A10C
         {
             DSMS ??= new DSMSSystem();
             HMCS ??= new HMCSSystem();
+            IFFCC ??= new IFFCCSystem();
             Misc ??= new MiscSystem();
             Radio ??= new RadioSystem();
             TAD ??= new TADSystem();
@@ -182,6 +190,7 @@ namespace JAFDTC.Models.A10C
                    (((systemTag != null) && (cboardTag.StartsWith(systemTag))) ||
                    ((systemTag == null) && (cboardTag == DSMSSystem.SystemTag)) ||
                    ((systemTag == null) && (cboardTag == HMCSSystem.SystemTag)) ||
+                   ((systemTag == null) && (cboardTag == IFFCCSystem.SystemTag)) ||
                    ((systemTag == null) && (cboardTag == MiscSystem.SystemTag)) ||
                    ((systemTag == null) && (cboardTag == RadioSystem.SystemTag)) ||
                    ((systemTag == null) && (cboardTag == TADSystem.SystemTag)) ||
@@ -199,6 +208,7 @@ namespace JAFDTC.Models.A10C
                 {
                     case DSMSSystem.SystemTag: DSMS = JsonSerializer.Deserialize<DSMSSystem>(json); break;
                     case HMCSSystem.SystemTag: HMCS = JsonSerializer.Deserialize<HMCSSystem>(json); break;
+                    case IFFCCSystem.SystemTag: IFFCC = JsonSerializer.Deserialize<IFFCCSystem>(json); break;
                     case MiscSystem.SystemTag: Misc = JsonSerializer.Deserialize<MiscSystem>(json); break;
                     case RadioSystem.SystemTag: Radio = JsonSerializer.Deserialize<RadioSystem>(json); break;
                     case TADSystem.SystemTag: TAD = JsonSerializer.Deserialize<TADSystem>(json); break;

--- a/JAFDTC/Models/A10C/A10CDeviceManager.cs
+++ b/JAFDTC/Models/A10C/A10CDeviceManager.cs
@@ -189,7 +189,11 @@ namespace JAFDTC.Models.A10C
             rmfd.AddAction(3018, "RMFD_18", delay, 1);
             rmfd.AddAction(3019, "RMFD_19", delay, 1);
             rmfd.AddAction(3020, "RMFD_20", delay, 1);
+
             rmfd.AddAction(3012, "RMFD_12_LONG", 2500, 1);
+            rmfd.AddAction(3018, "RMFD_18_SHORT", delayChar, 1); // for HMCS profile setting change
+            rmfd.AddAction(3019, "RMFD_19_SHORT", delayChar, 1); // for HMCS down arrow
+
             AddDevice(rmfd);
 
             // ---- up-front controls

--- a/JAFDTC/Models/A10C/A10CDeviceManager.cs
+++ b/JAFDTC/Models/A10C/A10CDeviceManager.cs
@@ -37,6 +37,7 @@ namespace JAFDTC.Models.A10C
         {
             int delay = Settings.CommandDelaysMs[AirframeTypes.A10C];
             int delayChar = delay / 2;
+            int delayData = delay / 4;
 
             // ---- cdu
 
@@ -194,25 +195,35 @@ namespace JAFDTC.Models.A10C
             // ---- up-front controls
 
             AirframeDevice ufc = new(8, "UFC");
+
+            ufc.AddAction(3001, "1", delayChar, 1);
+            ufc.AddAction(3002, "2", delayChar, 1);
+            ufc.AddAction(3003, "3", delayChar, 1);
+            ufc.AddAction(3004, "4", delayChar, 1);
+            ufc.AddAction(3005, "5", delayChar, 1);
+            ufc.AddAction(3006, "6", delayChar, 1);
+            ufc.AddAction(3007, "7", delayChar, 1);
+            ufc.AddAction(3008, "8", delayChar, 1);
+            ufc.AddAction(3009, "9", delayChar, 1);
+            ufc.AddAction(3010, "0", delayChar, 1);
+            ufc.AddAction(3011, "SPC", delayChar, 1);
+
+            ufc.AddAction(3013, "FN", delay, 1);
+            ufc.AddAction(3015, "CLR", delay, 1);
+            ufc.AddAction(3016, "ENTER", delay, 1);
+
+            ufc.AddAction(3018, "ALT_ALRT", delay, 1);
+
+            ufc.AddAction(3022, "DATA_UP", delayData, 1);
+            ufc.AddAction(3023, "DATA_DN", delayData, 1);
+            ufc.AddAction(3024, "SEL_UP", delayChar, 1);
+            ufc.AddAction(3025, "SEL_DN", delayChar, 1);
+
             ufc.AddAction(3030, "UFC_COM1", delay, 1);
             ufc.AddAction(3030, "UFC_COM1_LONG", 1500, 1);
             ufc.AddAction(3033, "UFC_COM2", delay, 1);
             ufc.AddAction(3033, "UFC_COM2_LONG", 1500, 1);
-            ufc.AddAction(3001, "1", delay, 1);
-            ufc.AddAction(3002, "2", delay, 1);
-            ufc.AddAction(3003, "3", delay, 1);
-            ufc.AddAction(3004, "4", delay, 1);
-            ufc.AddAction(3005, "5", delay, 1);
-            ufc.AddAction(3006, "6", delay, 1);
-            ufc.AddAction(3007, "7", delay, 1);
-            ufc.AddAction(3008, "8", delay, 1);
-            ufc.AddAction(3009, "9", delay, 1);
-            ufc.AddAction(3010, "0", delay, 1);
-            ufc.AddAction(3011, "SPC", delay, 1);
-            ufc.AddAction(3013, "FN", delay, 1);
-            ufc.AddAction(3015, "CLR", delay, 1);
-            ufc.AddAction(3016, "ENTER", delay, 1);
-            ufc.AddAction(3018, "ALT_ALRT", delay, 1);
+
             AddDevice(ufc);
 
             // ---- IFF
@@ -333,6 +344,14 @@ namespace JAFDTC.Models.A10C
             hotas.AddAction(548, "TMS_OFF", delay, 1);
 
             AddDevice(hotas);
+
+            // ---- AHCP (armament HUD control panel)
+
+            AirframeDevice ahcp = new(7, "AHCP");
+            ahcp.AddAction(3010, "IFFCC_OFF", delay, 0, 0);
+            ahcp.AddAction(3010, "IFFCC_TEST", delay, 0.1, 0.1);
+            ahcp.AddAction(3010, "IFFCC_ON", delay, 0.2, 0.2);
+            AddDevice(ahcp);
 
             // ---- aux light control
 

--- a/JAFDTC/Models/A10C/A10CDeviceManager.cs
+++ b/JAFDTC/Models/A10C/A10CDeviceManager.cs
@@ -42,6 +42,7 @@ namespace JAFDTC.Models.A10C
             // ---- cdu
 
             AirframeDevice cdu = new(9, "CDU");
+
             cdu.AddAction(3015, "1", delayChar, 1);
             cdu.AddAction(3016, "2", delayChar, 1);
             cdu.AddAction(3017, "3", delayChar, 1);
@@ -80,7 +81,8 @@ namespace JAFDTC.Models.A10C
             cdu.AddAction(3051, "Y", delayChar, 1);
             cdu.AddAction(3052, "Z", delayChar, 1);
             cdu.AddAction(3057, " ", delayChar, 1);
-            cdu.AddAction(3058, "CLR", delay, 1);
+            cdu.AddAction(3058, "CLR", delayChar, 1);
+
             cdu.AddAction(3001, "LSK_3L", delay, 1);
             cdu.AddAction(3002, "LSK_5L", delay, 1);
             cdu.AddAction(3003, "LSK_7L", delay, 1);
@@ -89,9 +91,11 @@ namespace JAFDTC.Models.A10C
             cdu.AddAction(3006, "LSK_5R", delay, 1);
             cdu.AddAction(3007, "LSK_7R", delay, 1);
             cdu.AddAction(3008, "LSK_9R", delay, 1);
+
             cdu.AddAction(3010, "NAV", delay, 1);
             cdu.AddAction(3011, "WP", delay, 1);
             cdu.AddAction(3013, "FPM", delay, 1);
+
             AddDevice(cdu);
 
             // ---- auxiliary avionics panel

--- a/JAFDTC/Models/A10C/A10CUploadAgent.cs
+++ b/JAFDTC/Models/A10C/A10CUploadAgent.cs
@@ -92,6 +92,7 @@ namespace JAFDTC.Models.A10C
         public override void BuildSystems(StringBuilder sb)
         {
             new RadioBuilder(_cfg, _dcsCmds, sb).Build();
+            new IFFCCBuilder(_cfg, _dcsCmds, sb).Build();
             new DSMSBuilder(_cfg, _dcsCmds, sb).Build();
             new HMCSBuilder(_cfg, _dcsCmds, sb).Build();
             new TADBuilder(_cfg, _dcsCmds, sb).Build();

--- a/JAFDTC/Models/A10C/DSMS/DSMSSystem.cs
+++ b/JAFDTC/Models/A10C/DSMS/DSMSSystem.cs
@@ -19,7 +19,6 @@
 //
 // ********************************************************************************************************************
 
-using JAFDTC.Utilities;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;

--- a/JAFDTC/Models/A10C/DSMS/MunitionSettings.cs
+++ b/JAFDTC/Models/A10C/DSMS/MunitionSettings.cs
@@ -19,7 +19,6 @@
 //
 // ********************************************************************************************************************
 
-using JAFDTC.Utilities;
 using System.Text.Json.Serialization;
 
 namespace JAFDTC.Models.A10C.DSMS
@@ -278,19 +277,34 @@ namespace JAFDTC.Models.A10C.DSMS
             }
         }
 
-        public readonly static MunitionSettings ExplicitDefaults = new()
+        private static MunitionSettings _default;
+        public static MunitionSettings ExplicitDefaults
         {
-            AutoLase = "False",
-            LaseSeconds = "0",
-            DeliveryMode = "",
-            EscapeManeuver = "1",   // CLB
-            ReleaseMode = "0",      // SGL
-            RippleQty = "1",
-            RippleFt = "75",
-            HOFOption = "6",        // 1800
-            RPMOption = "3",        // 1500
-            FuzeOption = "0"        // N/T
-        };
+            get
+            {
+                if (_default == null)
+                {
+                    _default = new MunitionSettings();
+                    Reset(_default);
+                }
+                return _default;
+            }
+        }
+
+        private static void Reset(MunitionSettings settings)
+        {
+            settings.AutoLase = "False";
+            settings.LaseSeconds = "0";
+            settings.DeliveryMode = "";
+            settings.EscapeManeuver = "1";   // CLB
+            settings.ReleaseMode = "0";      // SGL
+            settings.RippleQty = "1";
+            settings.RippleFt = "75";
+            settings.HOFOption = "6";        // 1800
+            settings.RPMOption = "3";        // 1500
+            settings.FuzeOption = "0";       // N/T
+        }
+
 
         private MunitionSettings()
         {
@@ -304,16 +318,7 @@ namespace JAFDTC.Models.A10C.DSMS
 
         public override void Reset()
         {
-            AutoLase = "False";
-            LaseSeconds = "0";
-            DeliveryMode = "";
-            EscapeManeuver = "1";   // CLB
-            ReleaseMode = "0";      // SGL
-            RippleQty = "1";
-            RippleFt = "75";
-            HOFOption = "6";        // 1800
-            RPMOption = "3";        // 1500
-            FuzeOption = "0";       // N/T
+            Reset(this);
         }
     }
 }

--- a/JAFDTC/Models/A10C/HMCS/HMCSSystem.cs
+++ b/JAFDTC/Models/A10C/HMCS/HMCSSystem.cs
@@ -174,9 +174,7 @@ namespace JAFDTC.Models.A10C.HMCS
 
         public override void Reset()
         {
-            ActiveProfile = "0";
-            TGPTrack = "0";
-            BrightnessSetting = "0";
+            Reset(this);
 
             _profileSettingMap = new Dictionary<Profiles, HMCSProfileSettings>
             {
@@ -208,12 +206,26 @@ namespace JAFDTC.Models.A10C.HMCS
         //
         // ------------------------------------------------------------------------------------------------------------
 
-        public readonly static HMCSSystem ExplicitDefaults = new()
+        private static HMCSSystem _default;
+        public static HMCSSystem ExplicitDefaults
         {
-            ActiveProfile = "0",
-            TGPTrack = "0",
-            BrightnessSetting = "0"
-        };
+            get
+            {
+                if (_default == null)
+                {
+                    _default = new HMCSSystem();
+                    Reset(_default);
+                }
+                return _default;
+            }
+        }
+
+        private static void Reset(HMCSSystem hmcs)
+        {
+            hmcs.ActiveProfile = "0";
+            hmcs.TGPTrack = "0";
+            hmcs.BrightnessSetting = "0";
+        }
 
     }
 }

--- a/JAFDTC/Models/A10C/IFFCC/IFFCCSystem.cs
+++ b/JAFDTC/Models/A10C/IFFCC/IFFCCSystem.cs
@@ -1,0 +1,484 @@
+﻿// ********************************************************************************************************************
+//
+// IFFCCSystem.cs -- a-10c iffcc system
+//
+// Copyright(C) 2024 fizzle, JAFDTC contributors
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
+// Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program.  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// ********************************************************************************************************************
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace JAFDTC.Models.A10C.IFFCC
+{
+    public enum CCIPConsentOptions
+    {
+        OFF = 0,
+        THREE_NINE,
+        FIVE_MIL
+    }
+
+    public enum AirspeedOptions
+    {
+        IAS = 0,
+        MACH_IAS,
+        GS,
+        TRUE
+    }
+
+    public class IFFCCSystem : SystemBase
+    {
+        public const string SystemTag = "JAFDTC:A10C:IFFCC";
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // properties
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        // ---- properties that post change and validation events
+
+        private string _ccipConsent;
+        public string CCIPConsent
+        {
+            get => _ccipConsent;
+            set => ValidateAndSetIntProp(value, 0, 2, ref _ccipConsent);
+        }
+
+        private string _isA10Enabled;
+        public string IsA10Enabled
+        {
+            get => _isA10Enabled;
+            set => ValidateAndSetBoolProp(value, ref _isA10Enabled);
+        }
+
+        private string _isF15Enabled;
+        public string IsF15Enabled
+        {
+            get => _isF15Enabled;
+            set => ValidateAndSetBoolProp(value, ref _isF15Enabled);
+        }
+
+        private string _isF16Enabled;
+        public string IsF16Enabled
+        {
+            get => _isF16Enabled;
+            set => ValidateAndSetBoolProp(value, ref _isF16Enabled);
+        }
+
+        private string _isF18Enabled;
+        public string IsF18Enabled
+        {
+            get => _isF18Enabled;
+            set => ValidateAndSetBoolProp(value, ref _isF18Enabled);
+        }
+
+        private string _isMig29Enabled;
+        public string IsMig29Enabled
+        {
+            get => _isMig29Enabled;
+            set => ValidateAndSetBoolProp(value, ref _isMig29Enabled);
+        }
+
+        private string _isSu27Enabled;
+        public string IsSu27Enabled
+        {
+            get => _isSu27Enabled;
+            set => ValidateAndSetBoolProp(value, ref _isSu27Enabled);
+        }
+
+        private string _isSu25Enabled;
+        public string IsSu25Enabled
+        {
+            get => _isSu25Enabled;
+            set => ValidateAndSetBoolProp(value, ref _isSu25Enabled);
+        }
+
+        private string _isAH64Enabled;
+        public string IsAH64Enabled
+        {
+            get => _isAH64Enabled;
+            set => ValidateAndSetBoolProp(value, ref _isAH64Enabled);
+        }
+
+        private string _isUH60Enabled;
+        public string IsUH60Enabled
+        {
+            get => _isUH60Enabled;
+            set => ValidateAndSetBoolProp(value, ref _isUH60Enabled);
+        }
+
+        private string _isMi8Enabled;
+        public string IsMi8Enabled
+        {
+            get => _isMi8Enabled;
+            set => ValidateAndSetBoolProp(value, ref _isMi8Enabled);
+        }
+
+        private string _fxdWingspan;
+        public string FxdWingspan
+        {
+            get => _fxdWingspan;
+            set => ValidateAndSetIntProp(value, 0, 99, ref _fxdWingspan);
+        }
+
+        private string _fxdLength;
+        public string FxdLength
+        {
+            get => _fxdLength;
+            set => ValidateAndSetIntProp(value, 10, 200, ref _fxdLength);
+        }
+
+        private string _fxdTgtSpeed;
+        public string FxdTgtSpeed
+        {
+            get => _fxdTgtSpeed;
+            set => ValidateAndSetIntProp(value, 50, 500, ref _fxdTgtSpeed);
+        }
+
+        private string _rtyWingspan;
+        public string RtyWingspan
+        {
+            get => _rtyWingspan;
+            set => ValidateAndSetIntProp(value, 0, 99, ref _rtyWingspan);
+        }
+
+        private string _rtyLength;
+        public string RtyLength
+        {
+            get => _rtyLength;
+            set => ValidateAndSetIntProp(value, 10, 200, ref _rtyLength);
+        }
+
+        private string _rtyTgtSpeed;
+        public string RtyTgtSpeed
+        {
+            get => _rtyTgtSpeed;
+            set => ValidateAndSetIntProp(value, 50, 500, ref _rtyTgtSpeed);
+        }
+
+        private string _autoDataDisplay;
+        public string AutoDataDisplay
+        {
+            get => _autoDataDisplay;
+            set => ValidateAndSetBoolProp(value, ref _autoDataDisplay);
+        }
+
+        // Pretty sure this is a funny translation failure. This should almost certainly be
+        // "occlude" not "occult" but it appears this way everywhere in both the manual and
+        // in-pit.
+        private string _ccipGunCrossOccult;
+        public string CCIPGunCrossOccult
+        {
+            get => _ccipGunCrossOccult;
+            set => ValidateAndSetBoolProp(value, ref _ccipGunCrossOccult);
+        }
+
+        private string _tapes;
+        public string Tapes
+        {
+            get => _tapes;
+            set => ValidateAndSetBoolProp(value, ref _tapes);
+        }
+
+        private string _metric;
+        public string Metric
+        {
+            get => _metric;
+            set => ValidateAndSetBoolProp(value, ref _metric);
+        }
+
+        private string _rdrAltTape;
+        public string RdrAltTape
+        {
+            get => _rdrAltTape;
+            set => ValidateAndSetBoolProp(value, ref _rdrAltTape);
+        }
+
+        private string _airspeed;
+        public string Airspeed
+        {
+            get => _airspeed;
+            set => ValidateAndSetIntProp(value, 0, 3, ref _airspeed);
+        }
+
+        private string _vertVel;
+        public string VertVel
+        {
+            get => _vertVel;
+            set => ValidateAndSetBoolProp(value, ref _vertVel);
+        }
+
+        // ---- synthesized properties
+
+        [JsonIgnore]
+        public override bool IsDefault => IsCCIPConsentDefault &&
+                                          IsAASDefault &&
+                                          IsDisplayModesDefault;
+
+        [JsonIgnore]
+        public bool IsAASDefault => IsA10EnabledDefault &&
+                                    IsF15EnabledDefault &&
+                                    IsF16EnabledDefault &&
+                                    IsF18EnabledDefault &&
+                                    IsMig29EnabledDefault &&
+                                    IsSu27EnabledDefault &&
+                                    IsSu25EnabledDefault &&
+                                    IsAH64EnabledDefault &&
+                                    IsUH60EnabledDefault &&
+                                    IsMi8EnabledDefault &&
+                                    IsFxdWingspanDefault &&
+                                    IsFxdLengthDefault &&
+                                    IsFxdTgtSpeedDefault &&
+                                    IsRtyWingspanDefault &&
+                                    IsRtyLengthDefault &&
+                                    IsRtyTgtSpeedDefault;
+
+        [JsonIgnore]
+        public bool IsDisplayModesDefault => IsAutoDataDisplayDefault &&
+                                             IsCCIPGunCrossOccultDefault &&
+                                             IsTapesDefault &&
+                                             IsMetricDefault &&
+                                             IsRdrAltTapeDefault &&
+                                             IsAirspeedDefault &&
+                                             IsVertVelDefault;
+
+        [JsonIgnore]
+        public bool IsCCIPConsentDefault => string.IsNullOrEmpty(CCIPConsent) || CCIPConsent == ExplicitDefaults.CCIPConsent;
+        [JsonIgnore]
+        public int CCIPConsentValue => string.IsNullOrEmpty(CCIPConsent) ? int.Parse(ExplicitDefaults.CCIPConsent) : int.Parse(CCIPConsent);
+
+        [JsonIgnore]
+        public bool IsA10EnabledDefault => string.IsNullOrEmpty(IsA10Enabled) || IsA10Enabled == ExplicitDefaults.IsA10Enabled;
+        [JsonIgnore]
+        public bool IsA10EnabledValue => string.IsNullOrEmpty(IsA10Enabled) ? bool.Parse(ExplicitDefaults.IsA10Enabled) : bool.Parse(IsA10Enabled);
+
+        [JsonIgnore]
+        public bool IsF15EnabledDefault => string.IsNullOrEmpty(IsF15Enabled) || IsF15Enabled == ExplicitDefaults.IsF15Enabled;
+        [JsonIgnore]
+        public bool IsF15EnabledValue => string.IsNullOrEmpty(IsF15Enabled) ? bool.Parse(ExplicitDefaults.IsF15Enabled) : bool.Parse(IsF15Enabled);
+
+        [JsonIgnore]
+        public bool IsF16EnabledDefault => string.IsNullOrEmpty(IsF16Enabled) || IsF16Enabled == ExplicitDefaults.IsF16Enabled;
+        [JsonIgnore]
+        public bool IsF16EnabledValue => string.IsNullOrEmpty(IsF16Enabled) ? bool.Parse(ExplicitDefaults.IsF16Enabled) : bool.Parse(IsF16Enabled);
+
+        [JsonIgnore]
+        public bool IsF18EnabledDefault => string.IsNullOrEmpty(IsF18Enabled) || IsF18Enabled == ExplicitDefaults.IsF18Enabled;
+        [JsonIgnore]
+        public bool IsF18EnabledValue => string.IsNullOrEmpty(IsF18Enabled) ? bool.Parse(ExplicitDefaults.IsF18Enabled) : bool.Parse(IsF18Enabled);
+
+        [JsonIgnore]
+        public bool IsMig29EnabledDefault => string.IsNullOrEmpty(IsMig29Enabled) || IsMig29Enabled == ExplicitDefaults.IsMig29Enabled;
+        [JsonIgnore]
+        public bool IsMig29EnabledValue => string.IsNullOrEmpty(IsMig29Enabled) ? bool.Parse(ExplicitDefaults.IsMig29Enabled) : bool.Parse(IsMig29Enabled);
+
+        [JsonIgnore]
+        public bool IsSu27EnabledDefault => string.IsNullOrEmpty(IsSu27Enabled) || IsSu27Enabled == ExplicitDefaults.IsSu27Enabled;
+        [JsonIgnore]
+        public bool IsSu27EnabledValue => string.IsNullOrEmpty(IsSu27Enabled) ? bool.Parse(ExplicitDefaults.IsSu27Enabled) : bool.Parse(IsSu27Enabled);
+
+        [JsonIgnore]
+        public bool IsSu25EnabledDefault => string.IsNullOrEmpty(IsSu25Enabled) || IsSu25Enabled == ExplicitDefaults.IsSu25Enabled;
+        [JsonIgnore]
+        public bool IsSu25EnabledValue => string.IsNullOrEmpty(IsSu25Enabled) ? bool.Parse(ExplicitDefaults.IsSu25Enabled) : bool.Parse(IsSu25Enabled);
+
+        [JsonIgnore]
+        public bool IsAH64EnabledDefault => string.IsNullOrEmpty(IsAH64Enabled) || IsAH64Enabled == ExplicitDefaults.IsAH64Enabled;
+        [JsonIgnore]
+        public bool IsAH64EnabledValue => string.IsNullOrEmpty(IsAH64Enabled) ? bool.Parse(ExplicitDefaults.IsAH64Enabled) : bool.Parse(IsAH64Enabled);
+
+        [JsonIgnore]
+        public bool IsUH60EnabledDefault => string.IsNullOrEmpty(IsUH60Enabled) || IsUH60Enabled == ExplicitDefaults.IsUH60Enabled;
+        [JsonIgnore]
+        public bool IsUH60EnabledValue => string.IsNullOrEmpty(IsUH60Enabled) ? bool.Parse(ExplicitDefaults.IsUH60Enabled) : bool.Parse(IsUH60Enabled);
+
+        [JsonIgnore]
+        public bool IsMi8EnabledDefault => string.IsNullOrEmpty(IsMi8Enabled) || IsMi8Enabled == ExplicitDefaults.IsMi8Enabled;
+        [JsonIgnore]
+        public bool IsMi8EnabledValue => string.IsNullOrEmpty(IsMi8Enabled) ? bool.Parse(ExplicitDefaults.IsMi8Enabled) : bool.Parse(IsMi8Enabled);
+
+        [JsonIgnore]
+        public bool IsFxdWingspanDefault => string.IsNullOrEmpty(FxdWingspan) || FxdWingspan == ExplicitDefaults.FxdWingspan;
+        [JsonIgnore]
+        public int FxdWingspanValue => string.IsNullOrEmpty(FxdWingspan) ? int.Parse(ExplicitDefaults.FxdWingspan) : int.Parse(FxdWingspan);
+
+        [JsonIgnore]
+        public bool IsFxdLengthDefault => string.IsNullOrEmpty(FxdLength) || FxdLength == ExplicitDefaults.FxdLength;
+        [JsonIgnore]
+        public int FxdLengthValue => string.IsNullOrEmpty(FxdLength) ? int.Parse(ExplicitDefaults.FxdLength) : int.Parse(FxdLength);
+
+        [JsonIgnore]
+        public bool IsFxdTgtSpeedDefault => string.IsNullOrEmpty(FxdTgtSpeed) || FxdTgtSpeed == ExplicitDefaults.FxdTgtSpeed;
+        [JsonIgnore]
+        public int FxdTgtSpeedValue => string.IsNullOrEmpty(FxdTgtSpeed) ? int.Parse(ExplicitDefaults.FxdTgtSpeed) : int.Parse(FxdTgtSpeed);
+
+        [JsonIgnore]
+        public bool IsRtyWingspanDefault => string.IsNullOrEmpty(RtyWingspan) || RtyWingspan == ExplicitDefaults.RtyWingspan;
+        [JsonIgnore]
+        public int RtyWingspanValue => string.IsNullOrEmpty(RtyWingspan) ? int.Parse(ExplicitDefaults.RtyWingspan) : int.Parse(RtyWingspan);
+
+        [JsonIgnore]
+        public bool IsRtyLengthDefault => string.IsNullOrEmpty(RtyLength) || RtyLength == ExplicitDefaults.RtyLength;
+        [JsonIgnore]
+        public int RtyLengthValue => string.IsNullOrEmpty(RtyLength) ? int.Parse(ExplicitDefaults.RtyLength) : int.Parse(RtyLength);
+
+        [JsonIgnore]
+        public bool IsRtyTgtSpeedDefault => string.IsNullOrEmpty(RtyTgtSpeed) || RtyTgtSpeed == ExplicitDefaults.RtyTgtSpeed;
+        [JsonIgnore]
+        public int RtyTgtSpeedValue => string.IsNullOrEmpty(RtyTgtSpeed) ? int.Parse(ExplicitDefaults.RtyTgtSpeed) : int.Parse(RtyTgtSpeed);
+
+        [JsonIgnore]
+        public bool IsAutoDataDisplayDefault => string.IsNullOrEmpty(AutoDataDisplay) || AutoDataDisplay == ExplicitDefaults.AutoDataDisplay;
+        [JsonIgnore]
+        public bool AutoDataDisplayValue => string.IsNullOrEmpty(AutoDataDisplay) ? bool.Parse(ExplicitDefaults.AutoDataDisplay) : bool.Parse(AutoDataDisplay);
+
+        [JsonIgnore]
+        public bool IsCCIPGunCrossOccultDefault => string.IsNullOrEmpty(CCIPGunCrossOccult) || CCIPGunCrossOccult == ExplicitDefaults.CCIPGunCrossOccult;
+        [JsonIgnore]
+        public bool CCIPGunCrossOccultValue => string.IsNullOrEmpty(CCIPGunCrossOccult) ? bool.Parse(ExplicitDefaults.CCIPGunCrossOccult) : bool.Parse(CCIPGunCrossOccult);
+
+        [JsonIgnore]
+        public bool IsTapesDefault => string.IsNullOrEmpty(Tapes) || Tapes == ExplicitDefaults.Tapes;
+        [JsonIgnore]
+        public bool TapesValue => string.IsNullOrEmpty(Tapes) ? bool.Parse(ExplicitDefaults.Tapes) : bool.Parse(Tapes);
+
+        [JsonIgnore]
+        public bool IsMetricDefault => string.IsNullOrEmpty(Metric) || Metric == ExplicitDefaults.Metric;
+        [JsonIgnore]
+        public bool MetricValue => string.IsNullOrEmpty(Metric) ? bool.Parse(ExplicitDefaults.Metric) : bool.Parse(Metric);
+
+        [JsonIgnore]
+        public bool IsRdrAltTapeDefault => string.IsNullOrEmpty(RdrAltTape) || RdrAltTape == ExplicitDefaults.RdrAltTape;
+        [JsonIgnore]
+        public bool RdrAltTapeValue => string.IsNullOrEmpty(RdrAltTape) ? bool.Parse(ExplicitDefaults.RdrAltTape) : bool.Parse(RdrAltTape);
+
+        [JsonIgnore]
+        public bool IsAirspeedDefault => string.IsNullOrEmpty(Airspeed) || Airspeed == ExplicitDefaults.Airspeed;
+        [JsonIgnore]
+        public int AirspeedValue => string.IsNullOrEmpty(Airspeed) ? int.Parse(ExplicitDefaults.Airspeed) : int.Parse(Airspeed);
+
+        [JsonIgnore]
+        public bool IsVertVelDefault => string.IsNullOrEmpty(VertVel) || VertVel == ExplicitDefaults.VertVel;
+        [JsonIgnore]
+        public int VertVelValue => string.IsNullOrEmpty(VertVel) ? int.Parse(ExplicitDefaults.VertVel) : int.Parse(VertVel);
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // construction
+        //
+        // ------------------------------------------------------------------------------------------------------------
+        public IFFCCSystem() 
+        {
+            Reset();
+        }
+
+        public IFFCCSystem(IFFCCSystem other)
+        {
+            CCIPConsent = other.CCIPConsent;
+
+            IsA10Enabled = other.IsA10Enabled;
+            IsF15Enabled = other.IsF15Enabled;
+            IsF16Enabled = other.IsF16Enabled;
+            IsF18Enabled = other.IsF18Enabled;
+            IsMig29Enabled = other.IsMig29Enabled;
+            IsSu27Enabled = other.IsSu27Enabled;
+            IsSu25Enabled = other.IsSu25Enabled;
+            IsAH64Enabled = other.IsAH64Enabled;
+            IsUH60Enabled = other.IsUH60Enabled;
+            IsMi8Enabled = other.IsMi8Enabled;
+
+            FxdWingspan = other.FxdWingspan;
+            FxdLength = other.FxdLength;
+            FxdTgtSpeed = other.FxdTgtSpeed;
+
+            RtyWingspan = other.RtyWingspan;
+            RtyLength = other.RtyLength;
+            RtyTgtSpeed = other.RtyTgtSpeed;
+
+            AutoDataDisplay = other.AutoDataDisplay;
+            CCIPGunCrossOccult = other.CCIPGunCrossOccult;
+            Tapes = other.Tapes;
+            Metric = other.Metric;
+            RdrAltTape = other.RdrAltTape;
+            Airspeed = other.Airspeed;
+            VertVel = other.VertVel;
+        }
+
+        public virtual object Clone() => new IFFCCSystem(this);
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // member methods
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        public override void Reset()
+        {
+            Reset(this);
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // static members
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        private static IFFCCSystem _default;
+        public static IFFCCSystem ExplicitDefaults
+        {
+            get
+            {
+                if (_default == null)
+                {
+                    _default = new IFFCCSystem();
+                    Reset(_default);
+                }
+                return _default;
+            }
+        }
+
+        private static void Reset(IFFCCSystem iffcc)
+        {
+            iffcc.CCIPConsent = "0";
+
+            iffcc.IsA10Enabled = "1";
+            iffcc.IsF15Enabled = "1";
+            iffcc.IsF16Enabled = "0";
+            iffcc.IsF18Enabled = "0";
+            iffcc.IsMig29Enabled = "0";
+            iffcc.IsSu27Enabled = "0";
+            iffcc.IsSu25Enabled = "1";
+            iffcc.IsAH64Enabled = "1";
+            iffcc.IsUH60Enabled = "0";
+            iffcc.IsMi8Enabled = "0";
+
+            iffcc.FxdWingspan = "0";
+            iffcc.FxdLength = "10";
+            iffcc.FxdTgtSpeed = "50";
+
+            iffcc.RtyWingspan = "0";
+            iffcc.RtyLength = "10";
+            iffcc.RtyTgtSpeed = "50";
+
+            iffcc.AutoDataDisplay = false.ToString();
+            iffcc.CCIPGunCrossOccult = true.ToString();
+            iffcc.Tapes = false.ToString();
+            iffcc.Metric = false.ToString();
+            iffcc.RdrAltTape = false.ToString();
+            iffcc.Airspeed = "0";
+            iffcc.VertVel = false.ToString();
+        }
+    }
+}

--- a/JAFDTC/Models/A10C/IFFCC/IFFCCSystem.cs
+++ b/JAFDTC/Models/A10C/IFFCC/IFFCCSystem.cs
@@ -25,8 +25,8 @@ namespace JAFDTC.Models.A10C.IFFCC
     public enum CCIPConsentOptions
     {
         OFF = 0,
-        THREE_NINE,
-        FIVE_MIL
+        FIVE_MIL,
+        THREE_NINE
     }
 
     public enum AirspeedOptions
@@ -228,22 +228,31 @@ namespace JAFDTC.Models.A10C.IFFCC
                                           IsDisplayModesDefault;
 
         [JsonIgnore]
-        public bool IsAASDefault => IsA10EnabledDefault &&
-                                    IsF15EnabledDefault &&
-                                    IsF16EnabledDefault &&
-                                    IsF18EnabledDefault &&
-                                    IsMig29EnabledDefault &&
-                                    IsSu27EnabledDefault &&
-                                    IsSu25EnabledDefault &&
-                                    IsAH64EnabledDefault &&
-                                    IsUH60EnabledDefault &&
-                                    IsMi8EnabledDefault &&
-                                    IsFxdWingspanDefault &&
-                                    IsFxdLengthDefault &&
-                                    IsFxdTgtSpeedDefault &&
-                                    IsRtyWingspanDefault &&
-                                    IsRtyLengthDefault &&
-                                    IsRtyTgtSpeedDefault;
+        public bool IsAASDefault => AreAircraftPresetsDefault &&
+                                    IsManFxdDefault &&
+                                    IsManRtyDefault;
+
+        [JsonIgnore]
+        public bool AreAircraftPresetsDefault => IsA10EnabledDefault &&
+                                                 IsF15EnabledDefault &&
+                                                 IsF16EnabledDefault &&
+                                                 IsF18EnabledDefault &&
+                                                 IsMig29EnabledDefault &&
+                                                 IsSu27EnabledDefault &&
+                                                 IsSu25EnabledDefault &&
+                                                 IsAH64EnabledDefault &&
+                                                 IsUH60EnabledDefault &&
+                                                 IsMi8EnabledDefault;
+
+        [JsonIgnore]
+        public bool IsManFxdDefault => IsFxdWingspanDefault &&
+                                       IsFxdLengthDefault &&
+                                       IsFxdTgtSpeedDefault;
+
+        [JsonIgnore]
+        public bool IsManRtyDefault => IsRtyWingspanDefault &&
+                                       IsRtyLengthDefault &&
+                                       IsRtyTgtSpeedDefault;
 
         [JsonIgnore]
         public bool IsDisplayModesDefault => IsAutoDataDisplayDefault &&

--- a/JAFDTC/Models/A10C/IFFCC/IFFCCSystem.cs
+++ b/JAFDTC/Models/A10C/IFFCC/IFFCCSystem.cs
@@ -177,7 +177,7 @@ namespace JAFDTC.Models.A10C.IFFCC
 
         // Pretty sure this is a funny translation failure. This should almost certainly be
         // "occlude" not "occult" but it appears this way everywhere in both the manual and
-        // in-pit.
+        // in-pit. Leaving it this way here, but I can't stand to leave "occult" in the UI.
         private string _ccipGunCrossOccult;
         public string CCIPGunCrossOccult
         {
@@ -453,16 +453,16 @@ namespace JAFDTC.Models.A10C.IFFCC
         {
             iffcc.CCIPConsent = "0";
 
-            iffcc.IsA10Enabled = "1";
-            iffcc.IsF15Enabled = "1";
-            iffcc.IsF16Enabled = "0";
-            iffcc.IsF18Enabled = "0";
-            iffcc.IsMig29Enabled = "0";
-            iffcc.IsSu27Enabled = "0";
-            iffcc.IsSu25Enabled = "1";
-            iffcc.IsAH64Enabled = "1";
-            iffcc.IsUH60Enabled = "0";
-            iffcc.IsMi8Enabled = "0";
+            iffcc.IsA10Enabled = true.ToString();
+            iffcc.IsF15Enabled = true.ToString();
+            iffcc.IsF16Enabled = false.ToString();
+            iffcc.IsF18Enabled = false.ToString();
+            iffcc.IsMig29Enabled = false.ToString();
+            iffcc.IsSu27Enabled = false.ToString();
+            iffcc.IsSu25Enabled = true.ToString();
+            iffcc.IsAH64Enabled = true.ToString();
+            iffcc.IsUH60Enabled = false.ToString();
+            iffcc.IsMi8Enabled = false.ToString();
 
             iffcc.FxdWingspan = "0";
             iffcc.FxdLength = "10";

--- a/JAFDTC/Models/A10C/Misc/MiscSystem.cs
+++ b/JAFDTC/Models/A10C/Misc/MiscSystem.cs
@@ -311,25 +311,19 @@ namespace JAFDTC.Models.A10C.Misc
         //
         // defaults are as of DCS v2.9.0.47168.
         //
-        public readonly static MiscSystem ExplicitDefaults = new()
+        private static MiscSystem _default;
+        public static MiscSystem ExplicitDefaults
         {
-            CoordSystem = "0",                  // Lat/Long
-            BullseyeOnHUD = false.ToString(),
-            FlightPlan1Manual = "0",            // Auto
-            SpeedDisplay = "0",                 // IAS
-            AapSteerPt = "0",                   // Flt Plan
-            AapPage = "0",                      // Other
-            AutopilotMode = "1",                // Alt/Hdg
-            TACANMode = "0",                    // Off
-            TACANBand = "0",                    // X
-            TACANChannel = "0",
-            IFFMasterMode = "0",                // Off
-            IFFMode3Code = "0000",
-            IFFMode4On = false.ToString(),
-            AGLFloor = "500",
-            MSLFloor = "0",
-            MSLCeiling = "0"
-        };
+            get
+            {
+                if (_default == null)
+                {
+                    _default = new MiscSystem();
+                    Reset(_default);
+                }
+                return _default;
+            }
+        }
 
         // returns true if the instance indicates a default setup (all fields are "") or the object is in explicit
         // form, false otherwise.
@@ -563,22 +557,27 @@ namespace JAFDTC.Models.A10C.Misc
         //
         public override void Reset()
         {
-            CoordSystem = "0";                  // LL
-            BullseyeOnHUD = false.ToString();
-            FlightPlan1Manual = "0";            // Auto
-            SpeedDisplay = "0";                 // IAS
-            AapSteerPt = "0";                   // FltPlan
-            AapPage = "0";                      // Other
-            AutopilotMode = "1";                // Alt/Hdg
-            TACANMode = "0";                    // Off
-            TACANBand = "0";                    // X
-            TACANChannel = "0";
-            IFFMasterMode = "0";                // Off
-            IFFMode3Code = "";
-            IFFMode4On = false.ToString();
-            AGLFloor = "500";
-            MSLFloor = "0";
-            MSLCeiling = "0";
+            Reset(this);
+        }
+
+        private static void Reset(MiscSystem misc)
+        {
+            misc.CoordSystem = "0";                  // LL
+            misc.BullseyeOnHUD = false.ToString();
+            misc.FlightPlan1Manual = "0";            // Auto
+            misc.SpeedDisplay = "0";                 // IAS
+            misc.AapSteerPt = "0";                   // FltPlan
+            misc.AapPage = "0";                      // Other
+            misc.AutopilotMode = "1";                // Alt/Hdg
+            misc.TACANMode = "0";                    // Off
+            misc.TACANBand = "0";                    // X
+            misc.TACANChannel = "0";
+            misc.IFFMasterMode = "0";                // Off
+            misc.IFFMode3Code = "0000";
+            misc.IFFMode4On = false.ToString();
+            misc.AGLFloor = "500";
+            misc.MSLFloor = "0";
+            misc.MSLCeiling = "0";
         }
     }
 }

--- a/JAFDTC/Models/A10C/TAD/TADSystem.cs
+++ b/JAFDTC/Models/A10C/TAD/TADSystem.cs
@@ -401,24 +401,8 @@ namespace JAFDTC.Models.A10C.TAD
 
         public override void Reset()
         {
-            CoordDisplay = "0";
-            GrpID = "";
-            OwnID = "";
-            Callsign = "";
-            HookOption = "0";
-            HookOwnship = "False";
-            MapRange = "0";
-            CenterDepress = "0";
-            MapOption = "0";
-            ProfileBullseye = "0";
-            ProfileRangeRings = "0";
-            ProfileHookInfo = "0";
-            ProfileWaypointLines = "0";
-            ProfileWaypointLabel = "0";
-            ProfileWaypoints = "0";
-            ProfileSPIDisplay = "0";
+            Reset(this);
         }
-
 
         // ------------------------------------------------------------------------------------------------------------
         //
@@ -426,24 +410,39 @@ namespace JAFDTC.Models.A10C.TAD
         //
         // ------------------------------------------------------------------------------------------------------------
 
-        public readonly static TADSystem ExplicitDefaults = new()
+        private static TADSystem _default;
+        public static TADSystem ExplicitDefaults
         {
-            CoordDisplay = "0",
-            GrpID = "",
-            OwnID = "",
-            Callsign = "",
-            HookOption = "0",
-            HookOwnship = "false",
-            MapRange = "0",
-            CenterDepress = "0",
-            MapOption = "0",
-            ProfileBullseye = "0",
-            ProfileRangeRings = "0",
-            ProfileHookInfo = "0",
-            ProfileWaypointLines = "0",
-            ProfileWaypointLabel = "0",
-            ProfileWaypoints = "0",
-            ProfileSPIDisplay = "0",
-        };
+            get
+            {
+                if (_default == null)
+                {
+                    _default = new TADSystem();
+                    Reset(_default);
+                }
+                return _default;
+            }
+        }
+
+        static private void Reset(TADSystem tad)
+        {
+            tad.CoordDisplay = "0";
+            tad.GrpID = "";
+            tad.OwnID = "";
+            tad.Callsign = "";
+            tad.HookOption = "0";
+            tad.HookOwnship = "False";
+            tad.MapRange = "0";
+            tad.CenterDepress = "0";
+            tad.MapOption = "0";
+            tad.ProfileBullseye = "0";
+            tad.ProfileRangeRings = "0";
+            tad.ProfileHookInfo = "0";
+            tad.ProfileWaypointLines = "0";
+            tad.ProfileWaypointLabel = "0";
+            tad.ProfileWaypoints = "0";
+            tad.ProfileSPIDisplay = "0";
+        }
+
     }
 }

--- a/JAFDTC/Models/A10C/TGP/TGPSystem.cs
+++ b/JAFDTC/Models/A10C/TGP/TGPSystem.cs
@@ -19,7 +19,6 @@
 //
 // ********************************************************************************************************************
 
-using JAFDTC.Utilities;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 
@@ -238,14 +237,7 @@ namespace JAFDTC.Models.A10C.TGP
 
         public override void Reset()
         {
-            CoordDisplay = "0"; // LL
-            VideoMode = "0";    // CCD
-            LaserCode = "1688";
-            LSS = "1688";
-            Latch = "True";     // ON
-            TAAF = "0";
-            FRND = "True";      // ON
-            Yardstick = "0";    // METRIC
+            Reset(this);
         }
 
         // ------------------------------------------------------------------------------------------------------------
@@ -254,16 +246,30 @@ namespace JAFDTC.Models.A10C.TGP
         //
         // ------------------------------------------------------------------------------------------------------------
 
-        public readonly static TGPSystem ExplicitDefaults = new()
+        private static TGPSystem _default;
+        public static TGPSystem ExplicitDefaults
         {
-            CoordDisplay = "0", // LL
-            VideoMode = "0",    // CCD
-            LaserCode = "1688",
-            LSS = "1688",
-            Latch = "True",     // ON
-            TAAF = "0",
-            FRND = "True",      // ON
-            Yardstick = "0",    // METRIC
-        };
+            get
+            {
+                if (_default == null)
+                {
+                    _default = new TGPSystem();
+                    Reset(_default);
+                }
+                return _default;
+            }
+        }
+
+        private static void Reset(TGPSystem tgp)
+        {
+            tgp.CoordDisplay = "0"; // LL
+            tgp.VideoMode = "0";    // CCD
+            tgp.LaserCode = "1688";
+            tgp.LSS = "1688";
+            tgp.Latch = "True";     // ON
+            tgp.TAAF = "0";
+            tgp.FRND = "True";      // ON
+            tgp.Yardstick = "0";    // METRIC
+        }
     }
 }

--- a/JAFDTC/Models/A10C/Upload/HMCSBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/HMCSBuilder.cs
@@ -105,57 +105,58 @@ namespace JAFDTC.Models.A10C.Upload
 
             // Do each setting, top to bottom.
             // This must be in the same order as the jet's list of settings.
+            const string BUTTON = "RMFD_18_SHORT";
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "Crosshair", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "Crosshair", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "OwnSPI", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "OwnSPI", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "SPIIndicator", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "SPIIndicator", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "HorizonLine", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "HorizonLine", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "HDC", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "HDC", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "Hookship", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "Hookship", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "TGPDiamond", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "TGPDiamond", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "TGPFOV", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "TGPFOV", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "FlightMembers", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "FlightMembers", profile);
             AddActionsForRangeProperty(cdu, rmfd, "FlightMembersRange", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "FMSPI", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "FMSPI", profile);
             AddActionsForRangeProperty(cdu, rmfd, "FMSPIRange", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "DonorAirPPLI", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "DonorAirPPLI", profile);
             AddActionsForRangeProperty(cdu, rmfd, "DonorAirPPLIRange", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "DonorSPI", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "DonorSPI", profile);
             AddActionsForRangeProperty(cdu, rmfd, "DonorSPIRange", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "CurrentMA", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "CurrentMA", profile);
             AddActionsForRangeProperty(cdu, rmfd, "CurrentMARange", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "AirEnvir", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "AirEnvir", profile);
             QueueContingentArrowDownAction();
 
             QueueContingentArrowDownAction(); // Skipped because no function in DCS: AIR VMF FRIEND
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "AirPPLINonDonor", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "AirPPLINonDonor", profile);
             AddActionsForRangeProperty(cdu, rmfd, "AirPPLINonDonorRange", profile);
             QueueContingentArrowDownAction();
 
@@ -165,10 +166,10 @@ namespace JAFDTC.Models.A10C.Upload
             QueueContingentArrowDownAction(); // Skipped because no function in DCS: AIR HOSTILE
             QueueContingentArrowDownAction(); // Skipped because no function in DCS: AIR OTHER
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "GndEnvir", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "GndEnvir", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "GndVMFFriend", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "GndVMFFriend", profile);
             AddActionsForRangeProperty(cdu, rmfd, "GndVMFFriendRange", profile);
             QueueContingentArrowDownAction();
 
@@ -180,33 +181,33 @@ namespace JAFDTC.Models.A10C.Upload
             QueueContingentArrowDownAction(); // Skipped because no function in DCS: GND OTHER
             QueueContingentArrowDownAction(); // Skipped because no function in DCS: EMER POINT
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "Steerpoint", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "Steerpoint", profile);
             AddActionsForRangeProperty(cdu, rmfd, "SteerpointRange", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "MsnMarkpoints", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "MsnMarkpoints", profile);
             AddActionsForRangeProperty(cdu, rmfd, "MsnMarkpointsRange", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "MsnMarkLabels", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "MsnMarkLabels", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "Airspeed", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "Airspeed", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "RadarAltitude", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "RadarAltitude", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "BaroAltitude", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "BaroAltitude", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "ACHeading", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "ACHeading", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "HelmetHeading", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "HelmetHeading", profile);
             QueueContingentArrowDownAction();
 
-            AddActionsForSettingProperty(rmfd, "RMFD_18", "HMDElevLines", profile);
+            AddActionsForSettingProperty(rmfd, BUTTON, "HMDElevLines", profile);
             QueueContingentArrowDownAction();
         }
 
@@ -248,7 +249,7 @@ namespace JAFDTC.Models.A10C.Upload
         private void AddAllContingentArrowDownActions(AirframeDevice rmfd)
         {
             for (int i = 0; i < _numContingentArrowDownActions; i++)
-                AddAction(rmfd, "RMFD_19");
+                AddAction(rmfd, "RMFD_19_SHORT");
             ClearAllContingentArrowDownActions();
         }
         int _numContingentArrowDownActions = 0;
@@ -267,7 +268,7 @@ namespace JAFDTC.Models.A10C.Upload
 
             // Add the actual setting changes.
             for (int i = 0; i < numClicks; i++)
-                AddAction(rmfd, button, WAIT_BASE);
+                AddAction(rmfd, button);
         }
 
         /// <summary>

--- a/JAFDTC/Models/A10C/Upload/IFFCCBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/IFFCCBuilder.cs
@@ -1,0 +1,263 @@
+﻿// ********************************************************************************************************************
+//
+// IFFCCBuilder.cs -- a-10c iffcc system builder
+//
+// Copyright(C) 2024 fizzle, JAFDTC contributors
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
+// Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program.  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// ********************************************************************************************************************
+
+using JAFDTC.Models.A10C.IFFCC;
+using JAFDTC.Models.DCS;
+using System.Collections.Generic;
+using System.Text;
+
+namespace JAFDTC.Models.A10C.Upload
+{
+    internal class IFFCCBuilder : A10CBuilderBase
+    {
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // construction
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        public IFFCCBuilder(A10CConfiguration cfg, A10CDeviceManager dcsCmds, StringBuilder sb) : base(cfg, dcsCmds, sb) { }
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // build methods
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        public override void Build(Dictionary<string, object> state = null)
+        {
+            if (_cfg.IFFCC.IsDefault)
+                return;
+
+            AirframeDevice ahcp = _aircraft.GetDevice("AHCP");
+            AirframeDevice ufc = _aircraft.GetDevice("UFC");
+
+            AddAction(ahcp, "IFFCC_TEST", WAIT_BASE);
+
+            BuildIFFCC(ufc);
+
+            //AddAction(ahcp, "IFFCC_ON");
+        }
+
+        private void BuildIFFCC(AirframeDevice ufc)
+        {
+            // CCIP Consent
+            int clicks = GetNumClicksForWraparoundSetting<CCIPConsentOptions>(IFFCCSystem.ExplicitDefaults.CCIPConsentValue,
+                                                                              _cfg.IFFCC.CCIPConsentValue);
+            AddActions(ufc, "DATA_DN", clicks);
+
+            BuildAAS(ufc);
+            BuildDisplayModes(ufc);
+        }
+
+        private void BuildAAS(AirframeDevice ufc)
+        {
+            AddAction(ufc, "SEL_DN");
+            AddAction(ufc, "SEL_DN");
+
+            if (_cfg.IFFCC.IsAASDefault)
+            {
+                AddAction(ufc, "SEL_DN");
+                return;
+            }
+
+            AddAction(ufc, "ENTER");
+
+            int queuedDnClicks = 0;
+
+            if (!_cfg.IFFCC.IsManFxdDefault)
+            {
+                AddAction(ufc, "ENTER");
+
+                if (!_cfg.IFFCC.IsFxdWingspanDefault)
+                    AddActions(ufc, "DATA_UP", _cfg.IFFCC.FxdWingspanValue - IFFCCSystem.ExplicitDefaults.FxdWingspanValue);
+                AddAction(ufc, "SEL_DN");
+
+                if (!_cfg.IFFCC.IsFxdLengthDefault)
+                    AddActions(ufc, "DATA_UP", _cfg.IFFCC.FxdLengthValue - IFFCCSystem.ExplicitDefaults.FxdLengthValue);
+                AddAction(ufc, "SEL_DN");
+
+                if (!_cfg.IFFCC.IsFxdTgtSpeedDefault)
+                    AddActions(ufc, "DATA_UP", _cfg.IFFCC.FxdTgtSpeedValue - IFFCCSystem.ExplicitDefaults.FxdTgtSpeedValue);
+                AddAction(ufc, "SEL_DN");
+
+                AddAction(ufc, "ENTER"); // enter exiting section moves the cursor down on AAS list
+            }
+            else
+                queuedDnClicks++;
+
+            if (!_cfg.IFFCC.IsManRtyDefault)
+            {
+                UnqueueDnClicks(ufc, ref queuedDnClicks);
+                AddAction(ufc, "ENTER");
+
+                if (!_cfg.IFFCC.IsRtyWingspanDefault)
+                    AddActions(ufc, "DATA_UP", _cfg.IFFCC.RtyWingspanValue - IFFCCSystem.ExplicitDefaults.RtyWingspanValue);
+                AddAction(ufc, "SEL_DN");
+
+                if (!_cfg.IFFCC.IsRtyLengthDefault)
+                    AddActions(ufc, "DATA_UP", _cfg.IFFCC.RtyLengthValue - IFFCCSystem.ExplicitDefaults.RtyLengthValue);
+                AddAction(ufc, "SEL_DN");
+
+                if (!_cfg.IFFCC.IsRtyTgtSpeedDefault)
+                    AddActions(ufc, "DATA_UP", _cfg.IFFCC.RtyTgtSpeedValue - IFFCCSystem.ExplicitDefaults.RtyTgtSpeedValue);
+                AddAction(ufc, "SEL_DN");
+
+                AddAction(ufc, "ENTER"); // enter exiting section moves the cursor down on AAS list
+            }
+            else
+                queuedDnClicks++;
+
+            if (!_cfg.IFFCC.AreAircraftPresetsDefault)
+            {
+                queuedDnClicks++;
+
+                if (!_cfg.IFFCC.IsA10EnabledDefault)
+                {
+                    UnqueueDnClicks(ufc, ref queuedDnClicks);
+                    AddAction(ufc, "ENTER");
+                }
+                queuedDnClicks++;
+
+                if (!_cfg.IFFCC.IsF15EnabledDefault)
+                {
+                    UnqueueDnClicks(ufc, ref queuedDnClicks);
+                    AddAction(ufc, "ENTER");
+                }
+                queuedDnClicks++;
+
+                if (!_cfg.IFFCC.IsF16EnabledDefault)
+                {
+                    UnqueueDnClicks(ufc, ref queuedDnClicks);
+                    AddAction(ufc, "ENTER");
+                }
+                queuedDnClicks++;
+
+                if (!_cfg.IFFCC.IsF18EnabledDefault)
+                {
+                    UnqueueDnClicks(ufc, ref queuedDnClicks);
+                    AddAction(ufc, "ENTER");
+                }
+                queuedDnClicks++;
+
+                if (!_cfg.IFFCC.IsMig29EnabledDefault)
+                {
+                    UnqueueDnClicks(ufc, ref queuedDnClicks);
+                    AddAction(ufc, "ENTER");
+                }
+                queuedDnClicks++;
+
+                if (!_cfg.IFFCC.IsSu27EnabledDefault)
+                {
+                    UnqueueDnClicks(ufc, ref queuedDnClicks);
+                    AddAction(ufc, "ENTER");
+                }
+                queuedDnClicks++;
+
+                if (!_cfg.IFFCC.IsSu25EnabledDefault)
+                {
+                    UnqueueDnClicks(ufc, ref queuedDnClicks);
+                    AddAction(ufc, "ENTER");
+                }
+                queuedDnClicks++;
+
+                if (!_cfg.IFFCC.IsAH64EnabledDefault)
+                {
+                    UnqueueDnClicks(ufc, ref queuedDnClicks);
+                    AddAction(ufc, "ENTER");
+                }
+                queuedDnClicks++;
+
+
+                if (!_cfg.IFFCC.IsUH60EnabledDefault)
+                {
+                    UnqueueDnClicks(ufc, ref queuedDnClicks);
+                    AddAction(ufc, "ENTER");
+                }
+                queuedDnClicks++;
+
+                if (!_cfg.IFFCC.IsMi8EnabledDefault)
+                {
+                    UnqueueDnClicks(ufc, ref queuedDnClicks);
+                    AddAction(ufc, "ENTER");
+                }
+                queuedDnClicks++;
+
+                queuedDnClicks += 2;
+            }
+
+            UnqueueDnClicks(ufc, ref queuedDnClicks);
+            AddAction(ufc, "ENTER");
+        }
+
+        private void BuildDisplayModes(AirframeDevice ufc)
+        {
+            if (_cfg.IFFCC.IsDisplayModesDefault)
+                return;
+
+            AddAction(ufc, "SEL_DN");
+            AddAction(ufc, "SEL_DN");
+            AddAction(ufc, "ENTER");
+
+            // Auto Data Display
+            if (!_cfg.IFFCC.IsAutoDataDisplayDefault)
+                AddAction(ufc, "DATA_DN");
+            AddAction(ufc, "SEL_DN");
+
+            // CCIP Gun Cross "Occult"
+            if (!_cfg.IFFCC.IsCCIPGunCrossOccultDefault)
+                AddAction(ufc, "DATA_DN");
+            AddAction(ufc, "SEL_DN");
+
+            // Tapes
+            if (!_cfg.IFFCC.IsTapesDefault)
+                AddAction(ufc, "DATA_DN");
+            AddAction(ufc, "SEL_DN");
+
+            // Metric
+            if (!_cfg.IFFCC.IsMetricDefault)
+                AddAction(ufc, "DATA_DN");
+            AddAction(ufc, "SEL_DN");
+
+            // Radar Alt Tape
+            if (!_cfg.IFFCC.IsRdrAltTapeDefault)
+                AddAction(ufc, "DATA_DN");
+            AddAction(ufc, "SEL_DN");
+
+            // Airspeed
+            if (!_cfg.IFFCC.IsAirspeedDefault)
+                AddActions(ufc, "DATA_DN", _cfg.IFFCC.AirspeedValue - IFFCCSystem.ExplicitDefaults.AirspeedValue);
+            AddAction(ufc, "SEL_DN");
+
+            // Vertical Velocity
+            if (!_cfg.IFFCC.IsVertVelDefault)
+                AddAction(ufc, "DATA_DN");
+            AddAction(ufc, "SEL_DN");
+
+            AddAction(ufc, "SEL_DN");
+            AddAction(ufc, "ENTER");
+        }
+
+        private void UnqueueDnClicks(AirframeDevice ufc, ref int queuedDnClicks)
+        {
+            AddActions(ufc, "SEL_DN", queuedDnClicks);
+            queuedDnClicks = 0;
+        }
+    }
+}

--- a/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/MiscBuilder.cs
@@ -155,7 +155,7 @@ namespace JAFDTC.Models.A10C.Upload
             // During startup, before alignment, the speed setting is not yet visible but you can still change it
             // with button presses. In this state we assume it's still at the default IAS and press the button
             // once for TAS, twice for GS.
-            AddIfBlock("SpeedIsNotAvailable", true, null, delegate ()
+            AddIfBlock("IsSpeedAvailable", false, null, delegate ()
             {
                 AddAction(cdu, "LSK_9R"); // TAS
                 if (miscSystem.SpeedDisplayValue == SpeedDisplayOptions.GS)
@@ -165,7 +165,7 @@ namespace JAFDTC.Models.A10C.Upload
             // TODO consider an "else" delegate for if blocks?
 
             // If we're aligned and can see the setting, we can just press the button until it says what we want.
-            AddIfBlock("SpeedIsAvailable", true, null, delegate ()
+            AddIfBlock("IsSpeedAvailable", true, null, delegate ()
             {
                 AddWhileBlock("SpeedIsNot", true, new() { $"{miscSystem.SpeedDisplayValue}" }, delegate ()
                 {

--- a/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
@@ -22,7 +22,6 @@ using JAFDTC.Models.DCS;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -57,6 +56,7 @@ namespace JAFDTC.Models.A10C.Upload
             ObservableCollection<WaypointInfo> wypts = _cfg.WYPT.Points;
             AirframeDevice cdu = _aircraft.GetDevice("CDU");
             AirframeDevice aap = _aircraft.GetDevice("AAP");
+            AirframeDevice rmfd = _aircraft.GetDevice("RMFD");
 
             if (wypts.Count > 0)
             {
@@ -73,13 +73,30 @@ namespace JAFDTC.Models.A10C.Upload
 
                 AddIfBlock("IsCoordFmtLL", true, null, delegate ()
                 {
-                    BuildWaypoints(cdu, wypts);
+                    AddIfBlock("IsCDUInDefaultMFDPosition", true, null, delegate ()
+                    {
+                        AddAction(rmfd, "RMFD_13");
+                        BuildWaypoints(cdu, wypts);
+                    });
+                    AddIfBlock("IsCDUInDefaultMFDPosition", false, null, delegate ()
+                    {
+                        BuildWaypoints(cdu, wypts);
+                    });
                 });
-                AddIfBlock("IsCoordFmtNotLL", true, null, delegate ()
+                AddIfBlock("IsCoordFmtLL", false, null, delegate ()
                 {
                     AddActions(cdu, new() { "LSK_9R" }); // Change to LL
-                    BuildWaypoints(cdu, wypts);
-                    AddActions(cdu, new() { "LSK_9R" }); // Go back to UTM
+                    AddIfBlock("IsCDUInDefaultMFDPosition", true, null, delegate ()
+                    {
+                        AddAction(rmfd, "RMFD_13");
+                        BuildWaypoints(cdu, wypts);
+                        AddActions(cdu, new() { "LSK_9R" }); // Go back to UTM
+                    });
+                    AddIfBlock("IsCDUInDefaultMFDPosition", false, null, delegate ()
+                    {
+                        BuildWaypoints(cdu, wypts);
+                        AddActions(cdu, new() { "LSK_9R" }); // Go back to UTM
+                    });
                 });
             }
         }

--- a/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
@@ -120,9 +120,15 @@ namespace JAFDTC.Models.A10C.Upload
                     // If no altitude was entered, leave it at the A-10's ground level altitude.
                     if (!string.IsNullOrEmpty(wypt.Alt))
                     {
-                        AddActions(cdu, ActionsForString(Math.Max(int.Parse(wypt.Alt), 0).ToString()), new() { "LSK_5L" });
-                        AddWait(WAIT_BASE);
-                        AddActions(cdu, new() { "CLR", "CLR" });
+                        // JAFDTC navpoints created from e.g. POIs always have an altitude.
+                        // For speed, only set altitude if it's different from the A-10's ground map elevation.
+                        AddIfBlock("IsWyptElevationDifferent", true, new() { wypt.Alt }, delegate ()
+                        {
+                            AddActions(cdu, ActionsForString(Math.Max(int.Parse(wypt.Alt), 0).ToString()), new() { "LSK_5L" });
+                            AddWait(WAIT_BASE);
+                            AddActions(cdu, new() { "CLR", "CLR" });
+                        });
+
                     }
                 }
             }

--- a/JAFDTC/Models/A10C/WYPT/WYPTSystem.cs
+++ b/JAFDTC/Models/A10C/WYPT/WYPTSystem.cs
@@ -20,7 +20,6 @@
 using JAFDTC.Models.Base;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 
 namespace JAFDTC.Models.A10C.WYPT
 {

--- a/JAFDTC/Models/DCS/BuilderBase.cs
+++ b/JAFDTC/Models/DCS/BuilderBase.cs
@@ -267,6 +267,20 @@ namespace JAFDTC.Models.DCS
         }
 
         /// <summary>
+        /// Perform the action count number of times, followed by a wait of dtWaitPost milliseconds.
+        /// </summary>
+        protected void AddActions(AirframeDevice device, string action, int count, int dtWaitPost = WAIT_NONE)
+        {
+            if (count < 1)
+                return;
+
+            for (int i = 0; i < count; i++)
+                AddAction(device, action);
+
+            AddWait(dtWaitPost);
+        }
+
+        /// <summary>
         /// add a wait command to the command stream the builder is building.
         /// </summary>
         protected void AddWait(int dt)

--- a/JAFDTC/Models/SystemBase.cs
+++ b/JAFDTC/Models/SystemBase.cs
@@ -18,6 +18,7 @@
 // ********************************************************************************************************************
 
 using JAFDTC.Utilities;
+using System.Runtime.CompilerServices;
 
 namespace JAFDTC.Models
 {
@@ -45,16 +46,16 @@ namespace JAFDTC.Models
 
         private const string INVALID_FORMAT = "Invalid format";
 
-        protected void ValidateAndSetIntProp(string value, int min, int max, ref string property)
+        protected void ValidateAndSetIntProp(string value, int min, int max, ref string property, [CallerMemberName] string propertyName = null)
         {
             string error = (string.IsNullOrEmpty(value) || IsIntegerFieldValid(value, min, max)) ? null : INVALID_FORMAT;
-            SetProperty(ref property, value, error);
+            SetProperty(ref property, value, error, propertyName);
         }
 
-        protected void ValidateAndSetBoolProp(string value, ref string property)
+        protected void ValidateAndSetBoolProp(string value, ref string property, [CallerMemberName] string propertyName = null)
         {
             string error = (string.IsNullOrEmpty(value) || IsBooleanFieldValid(value)) ? null : INVALID_FORMAT;
-            SetProperty(ref property, value, error);
+            SetProperty(ref property, value, error, propertyName);
         }
     }
 }

--- a/JAFDTC/Models/SystemBase.cs
+++ b/JAFDTC/Models/SystemBase.cs
@@ -27,8 +27,34 @@ namespace JAFDTC.Models
     /// </summary>
     public abstract class SystemBase : BindableObject, ISystem
     {
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // abstract definitions
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
         public abstract bool IsDefault { get; }
 
         public abstract void Reset();
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // property validate and set methods
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        private const string INVALID_FORMAT = "Invalid format";
+
+        protected void ValidateAndSetIntProp(string value, int min, int max, ref string property)
+        {
+            string error = (string.IsNullOrEmpty(value) || IsIntegerFieldValid(value, min, max)) ? null : INVALID_FORMAT;
+            SetProperty(ref property, value, error);
+        }
+
+        protected void ValidateAndSetBoolProp(string value, ref string property)
+        {
+            string error = (string.IsNullOrEmpty(value) || IsBooleanFieldValid(value)) ? null : INVALID_FORMAT;
+            SetProperty(ref property, value, error);
+        }
     }
 }

--- a/JAFDTC/UI/A10C/A10CConfigurationEditor.cs
+++ b/JAFDTC/UI/A10C/A10CConfigurationEditor.cs
@@ -21,6 +21,7 @@ using JAFDTC.Models;
 using JAFDTC.Models.A10C;
 using JAFDTC.Models.A10C.DSMS;
 using JAFDTC.Models.A10C.HMCS;
+using JAFDTC.Models.A10C.IFFCC;
 using JAFDTC.Models.A10C.Misc;
 using JAFDTC.Models.A10C.Radio;
 using JAFDTC.Models.A10C.TAD;
@@ -37,6 +38,7 @@ namespace JAFDTC.UI.A10C
     {
         public const string DSMS =  "\xEBD2";
         public const string HMCS =  "\xEA4A";
+        public const string IFFCC = "\xE70A";
         public const string MISC =  "\xE8B7";
         public const string RADIO = "\xE704";
         public const string TAD =   "\xE8B9";
@@ -61,6 +63,7 @@ namespace JAFDTC.UI.A10C
                 A10CEditTADPage.PageInfo,
                 A10CEditTGPPage.PageInfo,
                 A10CEditHMCSPage.PageInfo,
+                A10CEditIFFCCPage.PageInfo,
                 A10CEditMiscPage.PageInfo
             };
 
@@ -70,6 +73,7 @@ namespace JAFDTC.UI.A10C
             {
                 DSMSSystem.SystemTag => ((A10CConfiguration)config).DSMS,
                 HMCSSystem.SystemTag => ((A10CConfiguration)config).HMCS,
+                IFFCCSystem.SystemTag => ((A10CConfiguration)config).IFFCC,
                 MiscSystem.SystemTag => ((A10CConfiguration)config).Misc,
                 RadioSystem.SystemTag => ((A10CConfiguration)config).Radio,
                 TADSystem.SystemTag => ((A10CConfiguration)config).TAD,

--- a/JAFDTC/UI/A10C/A10CEditDSMSMunitionSettingsPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditDSMSMunitionSettingsPage.xaml.cs
@@ -114,7 +114,7 @@ namespace JAFDTC.UI.A10C
         /// </summary>
         protected override void UpdateUICustom(bool isEditable)
         {
-            if (!IsMunitionSelectionValid(out A10CMunition selectedMunition))
+            if (!IsMunitionSelectionValid(out A10CMunition selectedMunition) || EditState == null)
                return;
 
             SetLabelColorMatchingControlEnabledState(uiLabelLaserCode, uiTextLaserCode);

--- a/JAFDTC/UI/A10C/A10CEditIFFCCPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditIFFCCPage.xaml
@@ -195,8 +195,8 @@ https://www.gnu.org/licenses/.
                 <ComboBox.Items>
                     <!-- Must match enum order -->
                     <TextBlock Text="OFF"/>
-                    <TextBlock Text="3/9"/>
                     <TextBlock Text="5 MIL"/>
+                    <TextBlock Text="3/9"/>
                 </ComboBox.Items>
             </ComboBox>
 

--- a/JAFDTC/UI/A10C/A10CEditIFFCCPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditIFFCCPage.xaml
@@ -1,0 +1,402 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+**********************************************************************************************************************
+    
+A10CEditIFFCCPage.xaml : ui xaml for warthog iffcc page
+
+Copyright(C) 2024 fizzle
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+You should have received a copy of the GNU General Public License along with this program.  If not, see
+https://www.gnu.org/licenses/.
+
+**********************************************************************************************************************
+-->
+<base:SystemEditorPageBase
+    x:Class="JAFDTC.UI.A10C.A10CEditIFFCCPage"
+    xmlns:base="using:JAFDTC.UI.Base"
+    xmlns:controls="using:JAFDTC.UI.Controls"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:JAFDTC.UI.A10C"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Page.Resources>
+        <!-- brushes for error fields. -->
+        <SolidColorBrush x:Key="ErrorFieldBorderBrush" Color="DarkRed"/>
+        <SolidColorBrush x:Key="ErrorFieldBackgroundBrush" Color="PaleVioletRed"/>
+
+        <Style BasedOn="{StaticResource DefaultCheckBoxStyle}" TargetType="CheckBox">
+            <Setter Property="MinWidth" Value="20" />
+            <Setter Property="Width" Value="20" />
+        </Style>
+    </Page.Resources>
+
+    <Grid Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <!--
+        ===============================================================================================================
+        row 0 : iffcc settings
+        ===============================================================================================================
+        -->
+
+        <Grid Grid.Row="0" Margin="16,8,12,8" VerticalAlignment="Top" HorizontalAlignment="Center">
+            <Grid.RowDefinitions>
+                <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="50"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="30"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!--
+            ==========================================
+            left column
+            ==========================================
+            -->
+            
+            <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
+                       Style="{StaticResource EditorTitleTextBlockStyle}">
+                Display Modes:
+            </TextBlock>
+
+            <!-- AUTO DATA DISP -->
+            <TextBlock Grid.Row="1" Grid.Column="0" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                AUTO DATA DISP
+            </TextBlock>
+            <CheckBox Grid.Row="1" Grid.Column="1" Margin="12,12,0,0"
+                    x:Name="uiCheckAutoDataDisplay"
+                    Click="CheckBox_Clicked"
+                    Tag="AutoDataDisplay"
+                    ToolTipService.ToolTip="Briefly display release data on the HUD"/>
+
+            <!-- CCIP GUN CROSS OCCLUDE -->
+            <TextBlock Grid.Row="2" Grid.Column="0" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                CCIP GUN CROSS OCCLUDE
+            </TextBlock>
+            <CheckBox Grid.Row="2" Grid.Column="1" Margin="12,12,0,0"
+                    x:Name="uiCheckCCIPGunCrossOccult"
+                    Click="CheckBox_Clicked"
+                    Tag="CCIPGunCrossOccult"
+                    ToolTipService.ToolTip="Occlude the TVV behind the CCIP gun cross"/>
+
+            <!-- TAPES -->
+            <TextBlock Grid.Row="3" Grid.Column="0" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                TAPES
+            </TextBlock>
+            <CheckBox Grid.Row="3" Grid.Column="1" Margin="12,12,0,0"
+                    x:Name="uiCheckTapes"
+                    Click="CheckBox_Clicked"
+                    Tag="Tapes"
+                    ToolTipService.ToolTip="Display speed and altitude tapes instead of digital values"/>
+
+            <!-- METRIC -->
+            <TextBlock Grid.Row="4" Grid.Column="0" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                METRIC
+            </TextBlock>
+            <CheckBox Grid.Row="4" Grid.Column="1" Margin="12,12,0,0"
+                    x:Name="uiCheckMetric"
+                    Click="CheckBox_Clicked"
+                    Tag="Metric"
+                    ToolTipService.ToolTip="Display HUD data values in metric"/>
+
+            <!-- RDRALT TAPE -->
+            <TextBlock Grid.Row="5" Grid.Column="0" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                RDRALT TAPE
+            </TextBlock>
+            <CheckBox Grid.Row="5" Grid.Column="1" Margin="12,12,0,0"
+                    x:Name="uiCheckRdrAltTape"
+                    Click="CheckBox_Clicked"
+                    Tag="RdrAltTape"
+                    ToolTipService.ToolTip="Display a vertical tape indicating radar altitude"/>
+
+            <!-- AIRSPEED -->
+            <TextBlock Grid.Row="6" Grid.Column="0" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                AIRSPEED
+            </TextBlock>
+            <ComboBox Grid.Row="6" Grid.Column="1" Margin="12,12,0,0"
+                      x:Name="uiComboAirspeed"
+                      VerticalAlignment="Center"
+                      HorizontalAlignment="Left"
+                      SelectionChanged="ComboBox_SelectionChanged" Tag="Airspeed">
+                <ComboBox.Items>
+                    <!-- Must match enum order -->
+                    <TextBlock Text="IAS"/>
+                    <TextBlock Text="MACH/IAS"/>
+                    <TextBlock Text="GS"/>
+                    <TextBlock Text="TRUE"/>
+                </ComboBox.Items>
+            </ComboBox>
+
+            <!-- VERT VEL -->
+            <TextBlock Grid.Row="7" Grid.Column="0" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                VERT VEL
+            </TextBlock>
+            <CheckBox Grid.Row="7" Grid.Column="1" Margin="12,12,0,0"
+                    x:Name="uiCheckVertVel"
+                    Click="CheckBox_Clicked"
+                    Tag="VertVel"
+                    ToolTipService.ToolTip="Display vertical velocity on the left side of the HUD"/>
+
+            <TextBlock Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,24,0,0"
+                       Style="{StaticResource EditorTitleTextBlockStyle}">
+                Other:
+            </TextBlock>
+
+            <!-- CCIP Consent -->
+            <TextBlock Grid.Row="9" Grid.Column="0" Margin="12,12,0,0"
+                       Style="{StaticResource EditorParamStaticTextBlockStyle}"
+                       HorizontalTextAlignment="Right">
+                       CCIP CONSENT OPT
+            </TextBlock>
+            <ComboBox Grid.Row="9" Grid.Column="1" Margin="12,12,0,0"
+                      x:Name="uiComboCCIPConsent"
+                      VerticalAlignment="Center"
+                      HorizontalAlignment="Left"
+                      SelectionChanged="ComboBox_SelectionChanged" Tag="CCIPConsent">
+                <ComboBox.Items>
+                    <!-- Must match enum order -->
+                    <TextBlock Text="OFF"/>
+                    <TextBlock Text="3/9"/>
+                    <TextBlock Text="5 MIL"/>
+                </ComboBox.Items>
+            </ComboBox>
+
+            <!--
+            ==========================================
+            right column
+            ==========================================
+            -->
+
+            <TextBlock Grid.Row="0" Grid.Column="3" Grid.ColumnSpan="2"
+                       Style="{StaticResource EditorTitleTextBlockStyle}">
+                AAS:
+            </TextBlock>
+
+            <!-- A-10 -->
+            <TextBlock Grid.Row="1" Grid.Column="3" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                A-10
+            </TextBlock>
+            <CheckBox Grid.Row="1" Grid.Column="4" Margin="12,12,0,0"
+                    x:Name="uiCheckA10"
+                    Click="CheckBox_Clicked"
+                    Tag="IsA10Enabled"
+                    ToolTipService.ToolTip="Include air-to-air funnel preset for the A-10"/>
+
+            <!-- F-15 -->
+            <TextBlock Grid.Row="2" Grid.Column="3" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                F-15
+            </TextBlock>
+            <CheckBox Grid.Row="2" Grid.Column="4" Margin="12,12,0,0"
+                    x:Name="uiCheckF15"
+                    Click="CheckBox_Clicked"
+                    Tag="IsF15Enabled"
+                    ToolTipService.ToolTip="Include air-to-air funnel preset for the F-15"/>
+
+            <!-- F-16 -->
+            <TextBlock Grid.Row="3" Grid.Column="3" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                F-16
+            </TextBlock>
+            <CheckBox Grid.Row="3" Grid.Column="4" Margin="12,12,0,0"
+                    x:Name="uiCheckF16"
+                    Click="CheckBox_Clicked"
+                    Tag="IsF16Enabled"
+                    ToolTipService.ToolTip="Include air-to-air funnel preset for the F-16"/>
+
+            <!-- F-18 -->
+            <TextBlock Grid.Row="4" Grid.Column="3" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                F-18
+            </TextBlock>
+            <CheckBox Grid.Row="4" Grid.Column="4" Margin="12,12,0,0"
+                    x:Name="uiCheckF18"
+                    Click="CheckBox_Clicked"
+                    Tag="IsF18Enabled"
+                    ToolTipService.ToolTip="Include air-to-air funnel preset for the F-18"/>
+
+            <!-- MIG-29 -->
+            <TextBlock Grid.Row="5" Grid.Column="3" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                MIG-29
+            </TextBlock>
+            <CheckBox Grid.Row="5" Grid.Column="4" Margin="12,12,0,0"
+                    x:Name="uiCheckMig29"
+                    Click="CheckBox_Clicked"
+                    Tag="IsMig29Enabled"
+                    ToolTipService.ToolTip="Include air-to-air funnel preset for the MIG-29"/>
+
+            <!-- SU-27 -->
+            <TextBlock Grid.Row="1" Grid.Column="6" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                SU-27
+            </TextBlock>
+            <CheckBox Grid.Row="1" Grid.Column="7" Margin="12,12,0,0"
+                    x:Name="uiCheckSu27"
+                    Click="CheckBox_Clicked"
+                    Tag="IsSu27Enabled"
+                    ToolTipService.ToolTip="Include air-to-air funnel preset for the SU-27"/>
+
+            <!-- SU-25 -->
+            <TextBlock Grid.Row="2" Grid.Column="6" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                SU-25
+            </TextBlock>
+            <CheckBox Grid.Row="2" Grid.Column="7" Margin="12,12,0,0"
+                    x:Name="uiCheckSu25"
+                    Click="CheckBox_Clicked"
+                    Tag="IsSu25Enabled"
+                    ToolTipService.ToolTip="Include air-to-air funnel preset for the SU-25"/>
+
+            <!-- AH-64 -->
+            <TextBlock Grid.Row="3" Grid.Column="6" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                AH-64
+            </TextBlock>
+            <CheckBox Grid.Row="3" Grid.Column="7" Margin="12,12,0,0"
+                    x:Name="uiCheckAH64"
+                    Click="CheckBox_Clicked"
+                    Tag="IsAH64Enabled"
+                    ToolTipService.ToolTip="Include air-to-air funnel preset for the AH-64"/>
+
+            <!-- UH-60 -->
+            <TextBlock Grid.Row="4" Grid.Column="6" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                UH-60
+            </TextBlock>
+            <CheckBox Grid.Row="4" Grid.Column="7" Margin="12,12,0,0"
+                    x:Name="uiCheckUH60"
+                    Click="CheckBox_Clicked"
+                    Tag="IsUH60Enabled"
+                    ToolTipService.ToolTip="Include air-to-air funnel preset for the UH-60"/>
+
+            <!-- MI-8 HIP -->
+            <TextBlock Grid.Row="5" Grid.Column="6" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                MI-8 HIP
+            </TextBlock>
+            <CheckBox Grid.Row="5" Grid.Column="7" Margin="12,12,0,0"
+                    x:Name="uiCheckMI8"
+                    Click="CheckBox_Clicked"
+                    Tag="IsMi8Enabled"
+                    ToolTipService.ToolTip="Include air-to-air funnel preset for the MI-8 HIP"/>
+
+            <!-- FXD WNGSPN -->
+            <TextBlock Grid.Row="6" Grid.Column="3" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                FXD WNGSPN
+            </TextBlock>
+            <TextBox Grid.Row="6" Grid.Column="4" Margin="12,12,0,0" x:Name="uiTextFxdWingspan"
+                     HorizontalAlignment="Left" VerticalAlignment="Center"
+                     Style="{StaticResource EditorParamEditTextBoxStyle}"
+                     MaxLength="2"
+                     LostFocus="TextBox_LostFocus" GotFocus="TextBox_GotFocus" Tag="FxdWingspan"/>
+
+            <!-- FXD LENGTH -->
+            <TextBlock Grid.Row="7" Grid.Column="3" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                FXD LENGTH
+            </TextBlock>
+            <TextBox Grid.Row="7" Grid.Column="4" Margin="12,12,0,0" x:Name="uiTextFxdLength"
+                     HorizontalAlignment="Left" VerticalAlignment="Center"
+                     Style="{StaticResource EditorParamEditTextBoxStyle}"
+                     MaxLength="3"
+                     LostFocus="TextBox_LostFocus" GotFocus="TextBox_GotFocus" Tag="FxdLength"/>
+
+            <!-- FXD TGTSPEED -->
+            <TextBlock Grid.Row="8" Grid.Column="3" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                FXD TGTSPEED
+            </TextBlock>
+            <TextBox Grid.Row="8" Grid.Column="4" Margin="12,12,0,0" x:Name="uiTextFxdTgtSpeed"
+                     HorizontalAlignment="Left" VerticalAlignment="Center"
+                     Style="{StaticResource EditorParamEditTextBoxStyle}"
+                     MaxLength="3"
+                     LostFocus="TextBox_LostFocus" GotFocus="TextBox_GotFocus" Tag="FxdTgtSpeed"/>
+
+            <!-- RTY WNGSPN -->
+            <TextBlock Grid.Row="6" Grid.Column="6" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                RTY WNGSPN
+            </TextBlock>
+            <TextBox Grid.Row="6" Grid.Column="7" Margin="12,12,0,0" x:Name="uiTextRtyWingspan"
+                     HorizontalAlignment="Left" VerticalAlignment="Center"
+                     Style="{StaticResource EditorParamEditTextBoxStyle}"
+                     MaxLength="2"
+                     LostFocus="TextBox_LostFocus" GotFocus="TextBox_GotFocus" Tag="RtyWingspan"/>
+
+            <!-- RTY LENGTH -->
+            <TextBlock Grid.Row="7" Grid.Column="6" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                RTY LENGTH
+            </TextBlock>
+            <TextBox Grid.Row="7" Grid.Column="7" 
+                     Margin="12,12,0,0" x:Name="uiTextRtyLength"
+                     HorizontalAlignment="Left" VerticalAlignment="Center"
+                     Style="{StaticResource EditorParamEditTextBoxStyle}"
+                     MaxLength="3"
+                     LostFocus="TextBox_LostFocus" GotFocus="TextBox_GotFocus" Tag="RtyLength"/>
+
+            <!-- RTY TGTSPEED -->
+            <TextBlock Grid.Row="8" Grid.Column="6" Margin="12,12,0,0" VerticalAlignment="Center"
+                       Style="{ThemeResource EditorParamStaticTextBlockStyle}">
+                RTY TGTSPEED
+            </TextBlock>
+            <TextBox Grid.Row="8" Grid.Column="7" Margin="12,12,0,0" x:Name="uiTextRtyTgtSpeed"
+                     HorizontalAlignment="Left" VerticalAlignment="Center"
+                     Style="{StaticResource EditorParamEditTextBoxStyle}"
+                     MaxLength="3"
+                     LostFocus="TextBox_LostFocus" GotFocus="TextBox_GotFocus" Tag="RtyTgtSpeed"/>
+
+        </Grid>
+
+        <!--
+        ===============================================================================================================
+        row 1: link / reset
+        ===============================================================================================================
+        -->
+
+        <controls:LinkResetBtnsControl x:Name="uiCtlLinkResetBtns" Grid.Row="1"/>
+
+    </Grid>
+</base:SystemEditorPageBase>

--- a/JAFDTC/UI/A10C/A10CEditIFFCCPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditIFFCCPage.xaml
@@ -70,14 +70,14 @@ https://www.gnu.org/licenses/.
                 <RowDefinition/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="50"/>
                 <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*" MinWidth="50"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="30"/>
                 <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
             <!--
@@ -151,7 +151,7 @@ https://www.gnu.org/licenses/.
                        Style="{ThemeResource EditorParamStaticTextBlockStyle}">
                 AIRSPEED
             </TextBlock>
-            <ComboBox Grid.Row="6" Grid.Column="1" Margin="12,12,0,0"
+            <ComboBox Grid.Row="6" Grid.Column="1" Margin="12,12,0,0" Width="120"
                       x:Name="uiComboAirspeed"
                       VerticalAlignment="Center"
                       HorizontalAlignment="Left"

--- a/JAFDTC/UI/A10C/A10CEditIFFCCPage.xaml.cs
+++ b/JAFDTC/UI/A10C/A10CEditIFFCCPage.xaml.cs
@@ -1,0 +1,48 @@
+// ********************************************************************************************************************
+//
+// A10CEditTADPage.xaml.cs : ui c# for warthog iffcc page
+//
+// Copyright(C) 2024 fizzle
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
+// Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program.  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// ********************************************************************************************************************
+
+using JAFDTC.Models;
+using JAFDTC.Models.A10C;
+using JAFDTC.Models.A10C.IFFCC;
+using JAFDTC.UI.App;
+using JAFDTC.UI.Base;
+
+namespace JAFDTC.UI.A10C
+{
+    /// <summary>
+    /// Code-behind class for the A10 IFFCC editor.
+    /// </summary>
+    public sealed partial class A10CEditIFFCCPage : SystemEditorPageBase
+    {
+        private const string SYSTEM_NAME = "IFFCC";
+
+        protected override SystemBase SystemConfig => ((A10CConfiguration)Config).IFFCC;
+        protected override string SystemTag => IFFCCSystem.SystemTag;
+        protected override string SystemName => SYSTEM_NAME;
+
+        public static ConfigEditorPageInfo PageInfo
+            => new(IFFCCSystem.SystemTag, SYSTEM_NAME, SYSTEM_NAME, Glyphs.IFFCC, typeof(A10CEditIFFCCPage));
+
+        public A10CEditIFFCCPage()
+        {
+            InitializeComponent();
+            InitializeBase(new IFFCCSystem(), uiTextFxdLength, uiCtlLinkResetBtns);
+        }
+    }
+}

--- a/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditMiscPage.xaml
@@ -33,6 +33,11 @@ https://www.gnu.org/licenses/.
         <!-- brush for error fields. -->
         <SolidColorBrush x:Key="ErrorFieldBorderBrush" Color="DarkRed"/>
         <SolidColorBrush x:Key="ErrorFieldBackgroundBrush" Color="PaleVioletRed"/>
+
+        <Style BasedOn="{StaticResource DefaultCheckBoxStyle}" TargetType="CheckBox">
+            <Setter Property="MinWidth" Value="20" />
+            <Setter Property="Width" Value="20" />
+        </Style>
     </Page.Resources>
 
     <Grid>

--- a/JAFDTC/UI/A10C/A10CEditTADPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditTADPage.xaml
@@ -114,6 +114,7 @@ https://www.gnu.org/licenses/.
                      HorizontalAlignment="Left" VerticalAlignment="Center"
                      Style="{StaticResource EditorParamEditTextBoxStyle}"
                      MaxLength="4"
+                     ToolTipService.ToolTip="Four character reference for ownship, e.g. HG11"
                      LostFocus="TextBox_LostFocus" GotFocus="TextBox_GotFocus" Tag="Callsign"/>
 
             

--- a/JAFDTC/UI/A10C/A10CEditTADPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditTADPage.xaml
@@ -33,6 +33,11 @@ https://www.gnu.org/licenses/.
         <!-- brushes for error fields. -->
         <SolidColorBrush x:Key="ErrorFieldBorderBrush" Color="DarkRed"/>
         <SolidColorBrush x:Key="ErrorFieldBackgroundBrush" Color="PaleVioletRed"/>
+
+        <Style BasedOn="{StaticResource DefaultCheckBoxStyle}" TargetType="CheckBox">
+            <Setter Property="MinWidth" Value="20" />
+            <Setter Property="Width" Value="20" />
+        </Style>
     </Page.Resources>
 
 

--- a/JAFDTC/UI/A10C/A10CEditTGPPage.xaml
+++ b/JAFDTC/UI/A10C/A10CEditTGPPage.xaml
@@ -33,6 +33,11 @@ https://www.gnu.org/licenses/.
         <!-- brushes for error fields. -->
         <SolidColorBrush x:Key="ErrorFieldBorderBrush" Color="DarkRed"/>
         <SolidColorBrush x:Key="ErrorFieldBackgroundBrush" Color="PaleVioletRed"/>
+
+        <Style BasedOn="{StaticResource DefaultCheckBoxStyle}" TargetType="CheckBox">
+            <Setter Property="MinWidth" Value="20" />
+            <Setter Property="Width" Value="20" />
+        </Style>
     </Page.Resources>
 
 

--- a/JAFDTC/UI/Base/EditNavpointListPage.xaml.cs
+++ b/JAFDTC/UI/Base/EditNavpointListPage.xaml.cs
@@ -61,7 +61,7 @@ namespace JAFDTC.UI.Base
 
         protected override SystemBase SystemConfig => null;
 
-        protected override String SystemTag => PageHelper.SystemTag;
+        protected override string SystemTag => PageHelper.SystemTag;
 
         protected override string SystemName => PageHelper.NavptName;
 
@@ -443,7 +443,6 @@ namespace JAFDTC.UI.Base
 
             base.OnNavigatedTo(args);
 
-            CopyConfigToEditState();
             StartingNavptNum = (EditNavpt.Count > 0) ? EditNavpt[0].Number : 1;
 
             NavArgs.BackButton.IsEnabled = true;

--- a/JAFDTC/UI/Base/SystemEditorPageBase.cs
+++ b/JAFDTC/UI/Base/SystemEditorPageBase.cs
@@ -524,7 +524,7 @@ namespace JAFDTC.UI.Base
 
                 if (!bool.TryParse((string)property.GetValue(editState), out bool isChecked))
                 {
-                    FileManager.Log(string.Format("Unparseable bool ({0}) in {1}.{2} replaced with false.",
+                    FileManager.Log(string.Format("Unparseable bool ({0}) in {1}. {2} replaced with false.",
                                                   property.GetValue(editState), editState.GetType(), property.Name));
                     isChecked = false;
                 }


### PR DESCRIPTION
This branch primarily adds the IFFCC system editor for the A-10C II, which sets a bunch of HUD options:

![iffcc-editor](https://github.com/51st-Vfw/JAFDTC/assets/42720583/b451c347-70ab-4b46-8ab1-28373136254c)

While I was here I noticed a few things and fixed some odds and ends:

- `CustomUIUpdate()` was never being called in `EditNavpointListPage`, because it set `EditState` null, which led to the edit/copy/delete buttons always being enabled and crashing if they were clicked without selection. I [tweaked](https://github.com/51st-Vfw/JAFDTC/commit/953875db263029413519052f8910a651ea2f95de#diff-f8db557013d8550a41c127e9388f88c90b05c4ec0284ef5418e2ece22e1ce380) the behavior of SystemEditorPageBase.DoUIUpdate to fix that, and ensured existing derived `CustomUIUpdate()` implementations didn't break.
- A handful of speed improvements in A-10 uploads, shortening some delays and removing some unnecessary entry.
- Some minor A-10 LUA cleanup.
- Finally figured out how to [define system defaults just once](https://github.com/51st-Vfw/JAFDTC/commit/6c8018f9a2f32c3264a7eb7e53a75f7d59a27740) in A-10 system classes. 🤦‍♂️ 

Closes fizzle77#17