### PR TITLE
Fixes and tweaks in the Navpoint Editor

### DIFF
--- a/JAFDTC/AppResourceDict.xaml
+++ b/JAFDTC/AppResourceDict.xaml
@@ -66,4 +66,128 @@
         <Setter Property="VerticalAlignment" Value="Center"/>
     </Style>
 
+    <!-- style for editor textbox in a warning state 
+    
+    All this overhead is to preserve the style when the textbox is focused or the mouse is over it!
+    The default style was cribbed from generic.xaml and the "Focused" and "PointerOver" styles were removed.
+    Seems like there has to be a better way to do this, but I couldn't find it.
+    -->
+    <SolidColorBrush x:Key="WarningFieldBorderBrush" Color="Orange"/>
+    <SolidColorBrush x:Key="WarningFieldBackgroundBrush" Color="LightYellow"/>
+    <Style x:Key="WarningTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource EditorParamEditTextBoxStyle}">
+        <Setter Property="Background" Value="{ThemeResource WarningFieldBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource WarningFieldBorderBrush}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <Grid>
+                        <Grid.Resources>
+                            <Style x:Name="DeleteButtonStyle" TargetType="Button">
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="Button">
+                                            <Grid x:Name="ButtonLayoutGrid" Margin="{ThemeResource TextBoxInnerButtonMargin}" BorderBrush="{ThemeResource TextControlButtonBorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{ThemeResource TextControlButtonBackground}" BackgroundSizing="{TemplateBinding BackgroundSizing}" CornerRadius="{TemplateBinding CornerRadius}">
+
+                                                <VisualStateManager.VisualStateGroups>
+                                                    <VisualStateGroup x:Name="CommonStates">
+                                                        <VisualState x:Name="Normal" />
+
+                                                        <VisualState x:Name="PointerOver">
+                                                            <Storyboard>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="Background">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBackgroundPointerOver}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="BorderBrush">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBorderBrushPointerOver}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="GlyphElement" Storyboard.TargetProperty="Foreground">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonForegroundPointerOver}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                            </Storyboard>
+                                                        </VisualState>
+
+                                                        <VisualState x:Name="Pressed">
+                                                            <Storyboard>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="Background">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBackgroundPressed}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="BorderBrush">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBorderBrushPressed}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="GlyphElement" Storyboard.TargetProperty="Foreground">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonForegroundPressed}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                            </Storyboard>
+                                                        </VisualState>
+
+                                                        <VisualState x:Name="Disabled">
+                                                            <Storyboard>
+                                                                <DoubleAnimation Storyboard.TargetName="ButtonLayoutGrid"
+                                                                    Storyboard.TargetProperty="Opacity"
+                                                                    To="0"
+                                                                    Duration="0" />
+                                                            </Storyboard>
+                                                        </VisualState>
+                                                    </VisualStateGroup>
+                                                </VisualStateManager.VisualStateGroups>
+                                                <TextBlock x:Name="GlyphElement" Foreground="{ThemeResource TextControlButtonForeground}" VerticalAlignment="Center" HorizontalAlignment="Center" FontStyle="Normal" FontSize="{ThemeResource TextBoxIconFontSize}" Text="&#xE894;" FontFamily="{ThemeResource SymbolThemeFontFamily}" AutomationProperties.AccessibilityView="Raw" />
+                                            </Grid>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </Grid.Resources>
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="PointerOver"/>
+                                <VisualState x:Name="Focused" />
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="ButtonStates">
+                                <VisualState x:Name="ButtonVisible">
+
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DeleteButton" Storyboard.TargetProperty="Visibility">
+                                            <DiscreteObjectKeyFrame KeyTime="0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <Visibility>Visible</Visibility>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="ButtonCollapsed" />
+
+                            </VisualStateGroup>
+
+                        </VisualStateManager.VisualStateGroups>
+
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <ContentPresenter x:Name="HeaderContentPresenter" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Content="{TemplateBinding Header}" ContentTemplate="{TemplateBinding HeaderTemplate}" FontWeight="Normal" Foreground="{ThemeResource TextControlHeaderForeground}" Margin="{ThemeResource TextBoxTopHeaderMargin}" TextWrapping="Wrap" VerticalAlignment="Top" Visibility="Collapsed" x:DeferLoadStrategy="Lazy" />
+                        <Border x:Name="BorderElement" Grid.Row="1" Grid.Column="0" Grid.RowSpan="1" Grid.ColumnSpan="2" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}" Control.IsTemplateFocusTarget="True" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" />
+                        <ScrollViewer x:Name="ContentElement" Grid.Row="1" Grid.Column="0" HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}" IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}" IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}" Margin="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}" Foreground="{TemplateBinding Foreground}" IsTabStop="False" AutomationProperties.AccessibilityView="Raw" ZoomMode="Disabled" />
+                        <TextBlock x:Name="PlaceholderTextContentPresenter" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={ThemeResource TextControlPlaceholderForeground}}" Margin="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}" Text="{TemplateBinding PlaceholderText}" TextAlignment="{TemplateBinding TextAlignment}" TextWrapping="{TemplateBinding TextWrapping}" IsHitTestVisible="False" />
+                        <Button x:Name="DeleteButton" Grid.Row="1" Grid.Column="1" Style="{StaticResource DeleteButtonStyle}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}" Padding="{ThemeResource HelperButtonThemePadding}" IsTabStop="False" Visibility="Collapsed" AutomationProperties.AccessibilityView="Raw" FontSize="{TemplateBinding FontSize}" Width="30" VerticalAlignment="Stretch" />
+                        <ContentPresenter x:Name="DescriptionPresenter"
+                            Grid.Row="2"
+                            Grid.Column="0"
+                            Grid.ColumnSpan="2"
+                            Content="{TemplateBinding Description}"
+                            Foreground="{ThemeResource SystemControlDescriptionTextForegroundBrush}"
+                            AutomationProperties.AccessibilityView="Raw"
+                            x:Load="False"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
+++ b/JAFDTC/Models/A10C/Upload/WYPTBuilder.cs
@@ -106,6 +106,10 @@ namespace JAFDTC.Models.A10C.Upload
         /// </summary>
         private void BuildWaypoints(AirframeDevice cdu, ObservableCollection<WaypointInfo> jetWypts)
         {
+            // Ensure CDU scratchpad is clear before we start.
+            AddActions(cdu, new() { "CLR", "CLR" });
+            AddWait(WAIT_BASE);
+
             for (var i = 0; i < jetWypts.Count; i++)
             {
                 string wyptID = jetWypts[i].Number.ToString();
@@ -149,7 +153,7 @@ namespace JAFDTC.Models.A10C.Upload
             {
                 wyptName = wyptName[..12];
             }
-            AddActions(cdu, ActionsForString(wyptName), new(){ "LSK_7R" });
+            AddActions(cdu, ActionsForString(wyptName), new() { "LSK_7R" });
             AddWait(WAIT_BASE);
             AddActions(cdu, new() { "CLR", "CLR" });
         }

--- a/JAFDTC/Models/Import/ImportHelperJSON.cs
+++ b/JAFDTC/Models/Import/ImportHelperJSON.cs
@@ -69,7 +69,7 @@ namespace JAFDTC.Models.Import
             if (json != null)
             {
                 if (ImportIsPOIs(json))
-                    return navptSys.ImportSerializedPOIs(json);
+                    return navptSys.ImportSerializedPOIs(json, isReplace);
                 else
                     return navptSys.ImportSerializedNavpoints(json, isReplace);
             }

--- a/JAFDTC/UI/A10C/A10CEditWaypointHelper.cs
+++ b/JAFDTC/UI/A10C/A10CEditWaypointHelper.cs
@@ -44,6 +44,8 @@ namespace JAFDTC.UI.A10C
 
         public LLFormat NavptCoordFmt => LLFormat.DDM_P3ZF;
 
+        public int MaxNameLength => 12;
+
         public Dictionary<string, string> LatExtProperties
             => new()
             {

--- a/JAFDTC/UI/AV8B/AV8BEditWaypointHelper.cs
+++ b/JAFDTC/UI/AV8B/AV8BEditWaypointHelper.cs
@@ -45,6 +45,8 @@ namespace JAFDTC.UI.AV8B
 
         public LLFormat NavptCoordFmt => LLFormat.DMS;
 
+        public int MaxNameLength => 0;
+
         public Dictionary<string, string> LatExtProperties => null;
 
         public Dictionary<string, string> LonExtProperties => null;

--- a/JAFDTC/UI/Base/EditNavpointListPage.xaml
+++ b/JAFDTC/UI/Base/EditNavpointListPage.xaml
@@ -175,7 +175,7 @@ https://www.gnu.org/licenses/.
         common editor controls 
         ===============================================================================================================
         -->
-        <controls:LinkResetBtnsControl x:Name="uiCtlLinkResetBtns" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"/>
+        <controls:LinkResetBtnsControl x:Name="uiCtlLinkResetBtns" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"/>
 
     </Grid>
 </ui_base:SystemEditorPageBase>

--- a/JAFDTC/UI/Base/EditNavpointListPage.xaml.cs
+++ b/JAFDTC/UI/Base/EditNavpointListPage.xaml.cs
@@ -303,6 +303,8 @@ namespace JAFDTC.UI.Base
             DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Normal, () =>
             {
                 PageHelper.CaptureNavpoints(Config, wypts, CaptureIndex);
+                Config.Save(this, PageHelper.SystemTag);
+                CopyConfigToEditState();
             });
         }
 

--- a/JAFDTC/UI/Base/EditNavpointPage.xaml
+++ b/JAFDTC/UI/Base/EditNavpointPage.xaml
@@ -212,8 +212,11 @@ https://www.gnu.org/licenses/.
                         x:Name="uiNavptBtnPrev"
                         VerticalAlignment="Center"
                         Click="NavptBtnPrev_Click"
-                        ToolTipService.ToolTip="Move to previous navpoint for editing">
+                        ToolTipService.ToolTip="Move to previous navpoint for editing (Control+Shift+Enter)">
                     <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE70E;"/>
+                    <Button.KeyboardAccelerators>
+                        <KeyboardAccelerator Key="Enter" Modifiers="Control,Shift"/>
+                    </Button.KeyboardAccelerators>
                 </Button>
                 <Button Grid.Column="5" Margin="0,0,6,0"
                         x:Name="uiNavptBtnAdd"
@@ -226,8 +229,11 @@ https://www.gnu.org/licenses/.
                         x:Name="uiNavptBtnNext"
                         VerticalAlignment="Center"
                         Click="NavptBtnNext_Click"
-                        ToolTipService.ToolTip="Move to next navpoint for editing">
+                        ToolTipService.ToolTip="Move to next navpoint for editing (Control+Enter)">
                     <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE70D;"/>
+                    <Button.KeyboardAccelerators>
+                        <KeyboardAccelerator Key="Enter" Modifiers="Control"/>
+                    </Button.KeyboardAccelerators>
                 </Button>
             </Grid>
 
@@ -242,9 +248,9 @@ https://www.gnu.org/licenses/.
                      x:Name="uiNavptValueName"
                      Style="{StaticResource EditorParamEditTextBoxStyle}"
                      Text="{x:Bind EditNavpt.Name, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
-                     GotFocus="uiNavptValueName_GotFocus"
-                     TextChanged="uiNavptValueName_TextChanged"
-                     KeyUp="uiNavptValueName_KeyUp"
+                     GotFocus="NavptValueName_GotFocus"
+                     TextChanged="NavptValueName_TextChanged"
+                     PreviewKeyDown="TextBox_PreviewKeyDown"
                      MaxLength="48"
                      ToolTipService.ToolTip="Name of navpoint"/>
 
@@ -274,6 +280,7 @@ https://www.gnu.org/licenses/.
                          ui_ctk:TextBoxExtensions.CustomMask="N:[nNsS]"
                          ui_ctk:TextBoxExtensions.Mask="N 99° 99’ 99’’"
                          TextChanged="NavptTextBoxExt_TextChanged"
+                         PreviewKeyDown="TextBox_PreviewKeyDown"
                          ToolTipService.ToolTip="Latitude of navpoint"/>
                 <TextBox Grid.Row="0" Grid.Column="1" Margin="12,0,0,0"
                          x:Name="uiNavptValueLon"
@@ -285,6 +292,7 @@ https://www.gnu.org/licenses/.
                          ui_ctk:TextBoxExtensions.CustomMask="E:[eEwW]"
                          ui_ctk:TextBoxExtensions.Mask="E 999° 99’ 99’’"
                          TextChanged="NavptTextBoxExt_TextChanged"
+                         PreviewKeyDown="TextBox_PreviewKeyDown"
                          ToolTipService.ToolTip="Longitude of navpoint"/>
                 <TextBox Grid.Row="0" Grid.Column="2" Margin="24,0,0,0"
                          x:Name="uiNavptValueAlt"
@@ -292,6 +300,7 @@ https://www.gnu.org/licenses/.
                          Text="{x:Bind EditNavpt.Alt, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                          PlaceholderText="0"
                          MaxLength="8"
+                         PreviewKeyDown="TextBox_PreviewKeyDown"
                          ToolTipService.ToolTip="Elevation of navpoint in feet"/>
                 <TextBlock Grid.Row="0" Grid.Column="3" Margin="6,0,4,0"
                            x:Name="uiNavptAltitudeUnitsText"

--- a/JAFDTC/UI/Base/EditNavpointPage.xaml
+++ b/JAFDTC/UI/Base/EditNavpointPage.xaml
@@ -50,8 +50,6 @@ https://www.gnu.org/licenses/.
         <!-- brush for error fields. -->
         <SolidColorBrush x:Key="ErrorFieldBorderBrush" Color="DarkRed"/>
         <SolidColorBrush x:Key="ErrorFieldBackgroundBrush" Color="PaleVioletRed"/>
-        <SolidColorBrush x:Key="WarningFieldBorderBrush" Color="Orange"/>
-        <SolidColorBrush x:Key="WarningFieldBackgroundBrush" Color="LightYellow"/>
 
         <!-- style for ComboBoxSeparated -->
         <Style TargetType="ui_app:ComboBoxSeparated" BasedOn="{StaticResource DefaultComboBoxStyle}" />

--- a/JAFDTC/UI/Base/EditNavpointPage.xaml
+++ b/JAFDTC/UI/Base/EditNavpointPage.xaml
@@ -28,6 +28,7 @@ https://www.gnu.org/licenses/.
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
+    Loaded="Page_Loaded"
     Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}">
 
     <Page.Resources>
@@ -49,6 +50,8 @@ https://www.gnu.org/licenses/.
         <!-- brush for error fields. -->
         <SolidColorBrush x:Key="ErrorFieldBorderBrush" Color="DarkRed"/>
         <SolidColorBrush x:Key="ErrorFieldBackgroundBrush" Color="PaleVioletRed"/>
+        <SolidColorBrush x:Key="WarningFieldBorderBrush" Color="Orange"/>
+        <SolidColorBrush x:Key="WarningFieldBackgroundBrush" Color="LightYellow"/>
 
         <!-- style for ComboBoxSeparated -->
         <Style TargetType="ui_app:ComboBoxSeparated" BasedOn="{StaticResource DefaultComboBoxStyle}" />
@@ -239,6 +242,9 @@ https://www.gnu.org/licenses/.
                      x:Name="uiNavptValueName"
                      Style="{StaticResource EditorParamEditTextBoxStyle}"
                      Text="{x:Bind EditNavpt.Name, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
+                     GotFocus="uiNavptValueName_GotFocus"
+                     TextChanged="uiNavptValueName_TextChanged"
+                     KeyUp="uiNavptValueName_KeyUp"
                      MaxLength="48"
                      ToolTipService.ToolTip="Name of navpoint"/>
 

--- a/JAFDTC/UI/Base/EditNavpointPage.xaml.cs
+++ b/JAFDTC/UI/Base/EditNavpointPage.xaml.cs
@@ -201,14 +201,15 @@ namespace JAFDTC.UI.Base
         }
 
         /// <summary>
-        /// If the PageHelper specifies a non-zero maximum name length, indicate
-        /// when it is exceeded with a warning-yellow background and border.
+        /// If the PageHelper specifies a non-zero maximum name length,
+        /// indicate when it is exceeded with the warning style.
         /// </summary>
         private void ValidateNavptNameLength()
         {
-            bool isTooLong = PageHelper.MaxNameLength > 0 && uiNavptValueName.Text.Length > PageHelper.MaxNameLength;
-            uiNavptValueName.BorderBrush = (isTooLong) ? (SolidColorBrush)Resources["WarningFieldBorderBrush"] : _defaultBorderBrush;
-            uiNavptValueName.Background = (isTooLong) ? (SolidColorBrush)Resources["WarningFieldBackgroundBrush"] : _defaultBkgndBrush;
+            if (PageHelper.MaxNameLength > 0 && uiNavptValueName.Text.Length > PageHelper.MaxNameLength)
+                uiNavptValueName.Style = (Style)Application.Current.Resources["WarningTextBoxStyle"];
+            else
+                uiNavptValueName.Style = (Style)Application.Current.Resources["EditorParamEditTextBoxStyle"];
         }
 
         /// <summary>
@@ -568,11 +569,6 @@ namespace JAFDTC.UI.Base
         private void NavptValueName_GotFocus(object sender, RoutedEventArgs e)
         {
             uiNavptValueName.SelectAll();
-            
-            // This doesn't actually work to give the text box the warning appearance,
-            // presumably because the WinUI default focus styling happens later. This is fixable
-            // but I don't know how to do it yet. Leaving this here as a reminder.
-            //ValidateNavptNameLength();
         }
 
         /// <summary>
@@ -688,9 +684,9 @@ namespace JAFDTC.UI.Base
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
-            // Focus the name field when the page is loaded. Must be done here,
-            // rather than in OnNavigatedTo, because the visual tree is not yet
-            // available at that point.
+            // We do this here (and not in OnNavigatedTo) for two reasons:
+            // 1. The visual tree is done loading here.
+            // 2. We want this to happen every time you click a WP from the list.
             uiNavptValueName.Focus(FocusState.Programmatic);
         }
     }

--- a/JAFDTC/UI/Base/EditNavpointPage.xaml.cs
+++ b/JAFDTC/UI/Base/EditNavpointPage.xaml.cs
@@ -199,6 +199,17 @@ namespace JAFDTC.UI.Base
         }
 
         /// <summary>
+        /// If the PageHelper specifies a non-zero maximum name length, indicate
+        /// when it is exceeded with a warning-yellow background and border.
+        /// </summary>
+        private void ValidateNavptNameLength()
+        {
+            bool isTooLong = PageHelper.MaxNameLength > 0 && uiNavptValueName.Text.Length > PageHelper.MaxNameLength;
+            uiNavptValueName.BorderBrush = (isTooLong) ? (SolidColorBrush)Resources["WarningFieldBorderBrush"] : _defaultBorderBrush;
+            uiNavptValueName.Background = (isTooLong) ? (SolidColorBrush)Resources["WarningFieldBackgroundBrush"] : _defaultBkgndBrush;
+        }
+
+        /// <summary>
         /// TODO: document
         /// </summary>
         private void EditNavpt_DataValidationError(object sender, DataErrorsChangedEventArgs args)
@@ -508,6 +519,7 @@ namespace JAFDTC.UI.Base
             EditNavptIndex -= 1;
             CopyConfigToEdit(EditNavptIndex);
             RebuildInterfaceState();
+            uiNavptValueName.Focus(FocusState.Programmatic);
         }
 
         /// <summary>
@@ -521,6 +533,7 @@ namespace JAFDTC.UI.Base
             EditNavptIndex += 1;
             CopyConfigToEdit(EditNavptIndex);
             RebuildInterfaceState();
+            uiNavptValueName.Focus(FocusState.Programmatic);
         }
 
         /// <summary>
@@ -542,6 +555,36 @@ namespace JAFDTC.UI.Base
         private void NavptTextBoxExt_TextChanged(object sender, TextChangedEventArgs args)
         {
             RebuildInterfaceState();
+        }
+
+
+        private void uiNavptValueName_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            ValidateNavptNameLength();
+        }
+
+        private void uiNavptValueName_GotFocus(object sender, RoutedEventArgs e)
+        {
+            uiNavptValueName.SelectAll();
+            
+            // This doesn't actually work to give the text box the warning appearance,
+            // presumably because the WinUI default focus styling happens later. This is fixable
+            // but I don't know how to do it yet. Leaving this here as a reminder.
+            //ValidateNavptNameLength();
+        }
+
+        private void uiNavptValueName_KeyUp(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
+        {
+            // If <Enter> is pressed and the "Next" button is enabled, treat it as a click on the "Next" button.
+            if (e.Key == Windows.System.VirtualKey.Enter && uiNavptBtnNext.IsEnabled)
+            {
+                // Explicit property set is necessary because the binding updates
+                // on lost focus, which doesn't occur here.
+                EditNavpt.Name = uiNavptValueName.Text; 
+                NavptBtnNext_Click(sender, e);
+                uiNavptValueName.SelectAll();
+                e.Handled = true;
+            }
         }
 
         // ------------------------------------------------------------------------------------------------------------
@@ -601,6 +644,14 @@ namespace JAFDTC.UI.Base
             RebuildInterfaceState();
 
             base.OnNavigatedTo(args);
+        }
+
+        private void Page_Loaded(object sender, RoutedEventArgs e)
+        {
+            // Focus the name field when the page is loaded. Must be done here,
+            // rather than in OnNavigatedTo, because the visual tree is not yet
+            // available at that point.
+            uiNavptValueName.Focus(FocusState.Programmatic);
         }
     }
 }

--- a/JAFDTC/UI/Base/IEditNavpointPageHelper.cs
+++ b/JAFDTC/UI/Base/IEditNavpointPageHelper.cs
@@ -51,6 +51,12 @@ namespace JAFDTC.UI.Base
         public LLFormat NavptCoordFmt { get; }
 
         /// <summary>
+        /// Returns the maximum number of characters the jet will allow for a navpoint name.
+        /// If zero, the UI will not indicate a limit.
+        /// </summary>
+        public int MaxNameLength { get; }
+
+        /// <summary>
         /// returns a dictionary with the TextBoxExtensions to apply to the latitude field. the keys are property
         /// names for the extensions ("MaskPlaceholder", "Regex", "CustomMask", and "Mask"), values are the strings
         /// to set these to. null or an empty dictionary indicates the DMS coordinate defaults are used.

--- a/JAFDTC/UI/F14AB/F14ABEditWaypointHelper.cs
+++ b/JAFDTC/UI/F14AB/F14ABEditWaypointHelper.cs
@@ -46,6 +46,8 @@ namespace JAFDTC.UI.F14AB
 
         public LLFormat NavptCoordFmt => LLFormat.DDM_P1ZF;
 
+        public int MaxNameLength => 0;
+
         public Dictionary<string, string> LatExtProperties
             => new()
             {

--- a/JAFDTC/UI/FA18C/FA18CEditWaypointHelper.cs
+++ b/JAFDTC/UI/FA18C/FA18CEditWaypointHelper.cs
@@ -44,6 +44,8 @@ namespace JAFDTC.UI.FA18C
 
         public LLFormat NavptCoordFmt => LLFormat.DDM_P2ZF;
 
+        public int MaxNameLength => 0;
+
         public Dictionary<string, string> LatExtProperties
             => new()
             {

--- a/JAFDTC/UI/M2000C/M2000CEditWaypointHelper.cs
+++ b/JAFDTC/UI/M2000C/M2000CEditWaypointHelper.cs
@@ -46,6 +46,8 @@ namespace JAFDTC.UI.M2000C
 
         public LLFormat NavptCoordFmt => LLFormat.DDM_P3ZF;
 
+        public int MaxNameLength => 0;
+
         public Dictionary<string, string> LatExtProperties
             => new()
             {


### PR DESCRIPTION
### Fixes

1. Importing POIs to navpoints would replace even if you selected append.
2. Import from DCS (Send to JAFDTC from in-game Lua dialog) wasn't correctly doing a config save and UI update.
3. The navpoint list was overflowing over the Link/Reset buttons at the bottom.
4. In the A-10 waypoint upload, ensure the CDU scratchpad is empty before starting.

### Tweaks

I tried to streamline the flow where you create a bunch of navpoints from the in-game F10 map, send them to JAFDTC, then want to tweak them before uploading them to the jet.

1. Added `MaxNameLength` to `IEditNavpointPageHelper`. If an airframe specifies a max length, the navpoint name TextBox gets a yellow warning highlight when the name exceeds it. The change will still save in this state, it's just a visual warning that the name will be truncated.
2. Automatically focus the name field, and select its text, when the navpoint edit page loads. This makes changing the name or tabbing to other fields easy. No reaching for the mouse.
3. Add keyboard shortcuts (ctrl+enter, ctrl+shift+enter) for the next/prev buttons. Still no reaching for the mouse.

![wp-editor](https://github.com/51st-Vfw/JAFDTC/assets/42720583/52fd1fc2-b2d7-461c-84e7-b4419a5f5663)


