### PR TITLE
Radio editor fixes

### DIFF
--- a/JAFDTC/JAFDTC.csproj
+++ b/JAFDTC/JAFDTC.csproj
@@ -125,7 +125,6 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.2.250402" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250916003" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.6584" />
     <Manifest Include="$(ApplicationManifest)" />

--- a/JAFDTC/Properties/PublishProfiles/win-x64.pubxml
+++ b/JAFDTC/Properties/PublishProfiles/win-x64.pubxml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>x64</Platform>
+    <PublishDir>bin\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+  </PropertyGroup>
+</Project>

--- a/JAFDTC/UI/A10C/A10CEditRadioPageHelper.cs
+++ b/JAFDTC/UI/A10C/A10CEditRadioPageHelper.cs
@@ -174,19 +174,45 @@ namespace JAFDTC.UI.A10C
         public override bool RadioCanProgramModulation(int radio)
             => (radio == (int)RadioSystem.Radios.COMM1);
 
+        // These are bound to combo boxes, and the built-in binding behaves better when we don't build
+        // a new list every time, so we build a series of fixed lists we can return as appropriate.
+        private List<TextBlock> BothAmFirst => new()
+        {
+            new TextBlock() { Text = Modulation.AM.ToString(), Tag = ((int)Modulation.AM).ToString() },
+            new TextBlock() { Text = Modulation.FM.ToString(), Tag = ((int)Modulation.FM).ToString() },
+        };
+        private static List<TextBlock> BothFmFirst => new()
+        {
+            new TextBlock() { Text = Modulation.FM.ToString(), Tag = ((int)Modulation.FM).ToString() },
+            new TextBlock() { Text = Modulation.AM.ToString(), Tag = ((int)Modulation.AM).ToString() },
+        };
+        private static List<TextBlock> AmOnly => new()
+        {
+            new TextBlock() { Text = Modulation.AM.ToString(), Tag = ((int)Modulation.AM).ToString() },
+        };
+        private static List<TextBlock> FmOnly => new()
+        {
+            new TextBlock() { Text = Modulation.FM.ToString(), Tag = ((int)Modulation.FM).ToString() },
+        };
+
         public override List<TextBlock> RadioModulationItems(int radio, string freq)
         {
             if (radio == (int)RadioSystem.Radios.COMM1)
             {
                 Modulation[] mods = DefaultModulationForFreqOnRadio((RadioSystem.Radios)radio, freq);
-                if (mods != null)
+                if (mods.Length == 2)
                 {
-                    List<TextBlock> result = new List<TextBlock>();
-                    for (int i = 0; i < mods.Length; i++)
-                    {
-                        result.Add(new TextBlock() { Text = mods[i].ToString(), Tag = ((int)mods[i]).ToString() });
-                    }
-                    return result;
+                    if (mods[0] == Modulation.AM)
+                        return BothAmFirst;
+                    else
+                        return BothFmFirst;
+                }
+                else if (mods.Length == 1)
+                {
+                    if (mods[0] == Modulation.AM)
+                        return AmOnly;
+                    else
+                        return FmOnly;
                 }
             }
             return null;

--- a/JAFDTC/UI/Base/EditRadioPage.xaml
+++ b/JAFDTC/UI/Base/EditRadioPage.xaml
@@ -149,10 +149,9 @@ https://www.gnu.org/licenses/.
                                      Text="{x:Bind Frequency, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"/>
                             <ComboBox Grid.Column="2" Width="72" Margin="6,1,0,0"
                                       Tag="Modulation"
-                                      Visibility="{x:Bind ModulationVisibility, Mode=OneWay}"
-                                      ItemsSource="{Binding ModulationItems, Mode=OneWay}"
-                                      SelectedIndex="{x:Bind ModulationIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                      SelectionChanged="PreListModCombo_SelectionChanged"/>
+                                      Visibility="{x:Bind ModulationVisibility, Mode=OneTime}"
+                                      ItemsSource="{x:Bind ModulationItems, Mode=OneWay}"
+                                      SelectedIndex="{x:Bind ModulationIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                             <TextBox Grid.Column="3" Margin="6,0,0,0"
                                      VerticalAlignment="Center"
                                      HorizontalTextAlignment="Center"

--- a/JAFDTC/UI/Base/EditRadioPage.xaml
+++ b/JAFDTC/UI/Base/EditRadioPage.xaml
@@ -26,7 +26,7 @@ https://www.gnu.org/licenses/.
     xmlns:ui_base="using:JAFDTC.UI.Base"
     xmlns:ui_ctrl="using:JAFDTC.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" d:DataContext="{d:DesignInstance Type=local:RadioPresetItem}"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}">
 
@@ -136,6 +136,7 @@ https://www.gnu.org/licenses/.
                                      HorizontalTextAlignment="Center"
                                      MaxLength="2"
                                      Tag="Preset"
+                                     GotFocus="TextBox_GotFocus"
                                      IsEnabled="{x:Bind IsEnabled, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
                                      Text="{x:Bind Preset, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"/>
                             <TextBox Grid.Column="1" Margin="6,0,0,0"
@@ -143,17 +144,21 @@ https://www.gnu.org/licenses/.
                                      HorizontalTextAlignment="Left"
                                      MaxLength="7"
                                      Tag="Frequency"
+                                     GotFocus="TextBox_GotFocus"
                                      IsEnabled="{x:Bind IsEnabled, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
                                      Text="{x:Bind Frequency, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"/>
                             <ComboBox Grid.Column="2" Width="72" Margin="6,1,0,0"
                                       Tag="Modulation"
                                       Visibility="{x:Bind ModulationVisibility, Mode=OneWay}"
+                                      ItemsSource="{Binding ModulationItems, Mode=OneWay}"
+                                      SelectedIndex="{x:Bind ModulationIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                       SelectionChanged="PreListModCombo_SelectionChanged"/>
                             <TextBox Grid.Column="3" Margin="6,0,0,0"
                                      VerticalAlignment="Center"
                                      HorizontalTextAlignment="Center"
                                      Tag="Description"
                                      FontWeight="Medium"
+                                     GotFocus="TextBox_GotFocus"
                                      FontSize="16"
                                      IsEnabled="{x:Bind IsEnabled, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
                                      Text="{x:Bind Description, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"/>
@@ -196,6 +201,9 @@ https://www.gnu.org/licenses/.
                          VerticalAlignment="Center"
                          PlaceholderText="None Set"
                          MaxLength="7"
+                         GotFocus="TextBox_GotFocus"
+                         LostFocus="InitialFreq_LostFocus"
+                         Tag=""
                          Text="{x:Bind EditMisc.DefaultTuning, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"/>
                 <TextBlock Grid.Column="2" Margin="8,0,0,0"
                            x:Name="uiMiscTextDefaultLabel"

--- a/JAFDTC/UI/Base/EditRadioPage.xaml.cs
+++ b/JAFDTC/UI/Base/EditRadioPage.xaml.cs
@@ -27,9 +27,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Diagnostics;
 using Microsoft.UI.Dispatching;
-using System.Threading.Tasks;
+using System.Reflection;
 
 namespace JAFDTC.UI.Base
 {
@@ -47,8 +46,6 @@ namespace JAFDTC.UI.Base
         public int Radio { get; set; }
 
         public string Modulation { get; set; }
-
-        public List<TextBlock> ModulationItems { get; set; }
 
         private string _description;
         public string Description
@@ -88,7 +85,14 @@ namespace JAFDTC.UI.Base
         public int ModulationIndex
         {
             get => _modulationIndex;
-            set => SetProperty(ref _modulationIndex, value, null);
+            set => SetProperty(ref _modulationIndex, (value == -1) ? _modulationIndex : value, null);
+        }
+
+        private List<TextBlock> _modulationItems;
+        public List<TextBlock> ModulationItems
+        {
+            get => _modulationItems;
+            set => SetProperty(ref _modulationItems, value, null);
         }
 
         private bool _isEnabled;
@@ -112,7 +116,7 @@ namespace JAFDTC.UI.Base
     /// object presents a ui-centric generic version of the miscellaneous settings for a particular airframe suitable
     /// to binding to ui widgets.
     /// </summary>
-    public sealed partial class RadioMiscItem : BindableObject
+    public sealed class RadioMiscItem : BindableObject
     {
         public IEditRadioPageHelper PageHelper { get; }
 
@@ -185,7 +189,11 @@ namespace JAFDTC.UI.Base
 
         protected override string SystemName => "radio";
 
-        protected override bool IsPageStateDefault => (EditPresets.Count == 0);
+        protected override bool IsPageStateDefault =>
+            EditPresets.Count == 0 &&
+            PageHelper != null &&
+            Config != null &&
+            PageHelper.RadioSysIsDefault(Config);
 
         // ---- internal properties
 
@@ -207,12 +215,12 @@ namespace JAFDTC.UI.Base
 
         public EditRadioPage()
         {
-            EditPresets = [ ];
+            EditPresets = new ObservableCollection<RadioPresetItem>();
             EditRadio = 0;
             EditItemTag = 1;
 
             InitializeComponent();
-            InitializeBase(null, uiMiscValueDefaultFreq, uiCtlLinkResetBtns, [ ]);
+            InitializeBase(null, uiMiscValueDefaultFreq, uiCtlLinkResetBtns, new List<string>() { });
         }
 
         // ------------------------------------------------------------------------------------------------------------
@@ -226,26 +234,33 @@ namespace JAFDTC.UI.Base
         /// </summary>
         protected override void CopyConfigToEditState()
         {
-            foreach (RadioPresetItem item in EditPresets)
-            {
-                item.ErrorsChanged -= PreField_DataValidationError;
-                item.PropertyChanged -= PreField_PropertyChanged;
-            }
-
             PageHelper.CopyConfigToEdit(EditRadio, Config, EditPresets, EditMisc);
             SortEditPresets();
-            
+
             foreach (RadioPresetItem item in EditPresets)
             {
-                item.Tag = EditItemTag++;
-                item.ModulationItems = PageHelper.RadioModulationItems(EditRadio, item.Frequency);
-                item.ModulationIndex = ModulationIndexForModulation(item);
-
                 item.ErrorsChanged += PreField_DataValidationError;
                 item.PropertyChanged += PreField_PropertyChanged;
+                item.Tag = EditItemTag++;
+                item.ModulationItems = PageHelper.RadioModulationItems(EditRadio, item.Frequency);
+                if (item.ModulationItems != null)
+                {
+                    int modIndex = 0;
+                    for (int i = 0; i < item.ModulationItems.Count; i++)
+                    {
+                        if (item.Modulation == (string)item.ModulationItems[i].Tag)
+                        {
+                            modIndex = i;
+                            break;
+                        }
+                    }
+                    item.ModulationIndex = modIndex;
+                }
             }
 
             UpdateUIFromEditState();
+            uiCtlLinkResetBtns.SetResetButtonEnabled(!IsPageStateDefault);
+            PageHelper.RadioSysIsDefault(Config);
         }
 
         /// <summary>
@@ -267,6 +282,7 @@ namespace JAFDTC.UI.Base
                 PageHelper.CopyEditToConfig(EditRadio, EditPresets, EditMisc, Config);
                 Config.Save(this, PageHelper.SystemTag);
                 UpdateUIFromEditState();
+                uiCtlLinkResetBtns.SetResetButtonEnabled(!IsPageStateDefault);
             }
         }
 
@@ -280,12 +296,6 @@ namespace JAFDTC.UI.Base
         {
             Grid gridRow = Utilities.FindControl<Grid>(uiPreListView, typeof(Grid), item.Tag);
             return (gridRow != null) ? Utilities.FindControl<TextBox>(gridRow, typeof(TextBox), name) : null;
-        }
-
-        private ComboBox FindComboForPresetItem(RadioPresetItem item)
-        {
-            Grid gridRow = Utilities.FindControl<Grid>(uiPreListView, typeof(Grid), item.Tag);
-            return (gridRow != null) ? Utilities.FindControl<ComboBox>(gridRow, typeof(ComboBox), "Modulation") : null;
         }
 
         private void ValidateAllFields()
@@ -415,9 +425,9 @@ namespace JAFDTC.UI.Base
         /// </summary>
         private void SortEditPresets()
         {
-            List<RadioPresetItem> sortableList = [.. EditPresets ];
+            List<RadioPresetItem> sortableList = new(EditPresets);
             sortableList.Sort((a, b) => int.Parse(a.Preset).CompareTo(int.Parse(b.Preset)));
-            EditPresets = [ ];
+            EditPresets = new ObservableCollection<RadioPresetItem>();
             for (int i = 0; i < sortableList.Count; i++)
                 EditPresets.Add(sortableList[i]);
         }
@@ -458,30 +468,13 @@ namespace JAFDTC.UI.Base
         }
 
         /// <summary>
-        /// TODO: document
-        /// </summary>
-        private static bool IsModulationItemsEqual(ComboBox combo, RadioPresetItem item)
-        {
-            if ((combo.ItemsSource != null) &&
-                (item.ModulationItems != null) &&
-                (combo.Items.Count == item.ModulationItems.Count))
-            {
-                for (int i = 0; i < combo.Items.Count; i++)
-                    if (((TextBlock)combo.Items[i]).Text != item.ModulationItems[i].Text)
-                        return false;
-                return true;
-            }
-            return false;
-        }
-
-        /// <summary>
         /// update the "blue dot" state on the radio select menu to show the blue dot when the setup of the
         /// corresponding radio differs from defaults.
         /// </summary>
         private void RebuildRadioSelectMenu()
         {
             Utilities.SetBulletsInBulletComboBox(uiRadSelectCombo,
-                                                 i => !PageHelper.RadioModuleIsDefault(Config, i));
+                                                 (int i) => !PageHelper.RadioModuleIsDefault(Config, i));
         }
 
         /// <summary>
@@ -518,59 +511,6 @@ namespace JAFDTC.UI.Base
         }
 
         /// <summary>
-        /// update the per-preset modulation comboboxen. this method does nothing if the current radio does not
-        /// support per-preset modulation programming. depending on the state of the visual hierarchy, this
-        /// may schedule work for down the road.
-        /// </summary>
-        private void RebuildPerPresetModulationSelections()
-        {
-            if (!PageHelper.RadioCanProgramModulation(EditRadio))
-                return;
-
-            // TODO: revisit this code, it's proving to be fragile and the hack is maybe no longer a great idea.
-
-            // HACK: this shite seems to be necessary due to a gnarly interaction between Move and bindings.
-            // HACK: were life fair, we'd manage the modulation combo items and selections through bindings.
-            // HACK: tried that, it crashed.
-            //
-            foreach (RadioPresetItem item in EditPresets)
-            {
-                ComboBox combo = FindComboForPresetItem(item);
-                if ((combo != null) && (item.ModulationItems == null))
-                {
-                    combo.ItemsSource = null;
-                }
-                else if (combo != null)
-                {
-                    if (!IsModulationItemsEqual(combo, item))
-                    {
-                        combo.ItemsSource = item.ModulationItems;
-                        combo.SelectionChanged -= PreListModCombo_SelectionChanged;
-                        combo.SelectedIndex = item.ModulationIndex;
-                        combo.SelectionChanged += PreListModCombo_SelectionChanged;
-                    }
-                    else if (combo.SelectedIndex != item.ModulationIndex)
-                    {
-                        combo.SelectedIndex = item.ModulationIndex;
-                    }
-                }
-                else if (combo == null)
-                {
-                    // list view's view hierarchy hasn't been built out yet, revisit this setup later once the
-                    // hierarchy is built (which it will be, eventually). we'll wait a jiffy before trying again to
-                    // avoid pestering the framework too much: "ARE WE THERE YET?!?".
-                    //
-                    DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, async () =>
-                    {
-                        await Task.Delay(250);
-                        RebuildPerPresetModulationSelections();
-                    });
-                    break;
-                }
-            }
-        }
-
-        /// <summary>
         /// update the enable state on the ui elements based on the current settings. link controls must be set up via
         /// RebuildLinkControls() prior to calling this function.
         /// </summary>
@@ -580,7 +520,6 @@ namespace JAFDTC.UI.Base
 
             RebuildRadioSelectMenu();
             RebuildPerRadioMiscControls();
-            RebuildPerPresetModulationSelections();
 
             if ((EditPresets.Count > 0) && (EditPresets[0].IsEnabled != isEditable))
                 foreach (RadioPresetItem item in EditPresets)
@@ -758,14 +697,27 @@ namespace JAFDTC.UI.Base
 
             base.OnNavigatedTo(args);
 
-            List<FrameworkElement> items = [ ];
+            List<FrameworkElement> items = new();
             for (int i = 0; i < PageHelper.RadioNames.Count; i++)
-                    items.Add(Utilities.BulletComboBoxItem(PageHelper.RadioNames[i], i.ToString()));
+                items.Add(Utilities.BulletComboBoxItem(PageHelper.RadioNames[i], i.ToString()));
             uiRadSelectCombo.ItemsSource = items;
 
             CopyConfigToEditState();
 
             uiRadSelectCombo.SelectedIndex = EditRadio;
+        }
+
+        private void InitialFreq_LostFocus(object sender, RoutedEventArgs _)
+        {
+            TextBox textBox = (TextBox)sender;
+            BindableObject editState = EditMisc;
+            PropertyInfo property = editState.GetType().GetProperty("DefaultTuning");
+
+            if (!IsUIRebuilding && (property != null) && (editState != null))
+            {
+                property.SetValue(editState, textBox.Text);
+                SaveEditStateToConfig();
+            }
         }
     }
 }

--- a/JAFDTC/UI/Base/EditRadioPage.xaml.cs
+++ b/JAFDTC/UI/Base/EditRadioPage.xaml.cs
@@ -363,6 +363,11 @@ namespace JAFDTC.UI.Base
                 RadioPresetItem item = (RadioPresetItem)sender;
                 item.ModulationItems = PageHelper.RadioModulationItems(EditRadio, item.Frequency);
                 item.ModulationIndex = ModulationIndexForModulation(item);
+
+                // Binding doesn't correctly update the selection here, but doing it manually seems to work.
+                Grid gridRow = Utilities.FindControl<Grid>(uiPreListView, typeof(Grid), item.Tag);
+                ComboBox cb = Utilities.FindControl<ComboBox>(gridRow, typeof(ComboBox), "Modulation");
+                if (cb != null) cb.SelectedIndex = ModulationIndexForModulation(item);
             }
             DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
             {

--- a/JAFDTC/UI/Utilities.cs
+++ b/JAFDTC/UI/Utilities.cs
@@ -289,8 +289,9 @@ namespace JAFDTC.UI
                 for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
                 {
                     UIElement child = VisualTreeHelper.GetChild(parent, i) as UIElement;
-                    if (FindControl<T>(child, targetType, tag) != null)
-                        return FindControl<T>(child, targetType, tag);
+                    T control = FindControl<T>(child, targetType, tag);
+                    if (control != null)
+                        return control;
                 }
             }
             return result;


### PR DESCRIPTION
Resubmitting the radio editor fixes from https://github.com/51st-Vfw/JAFDTC/pull/63/commits/bc1bbc7609f1e7e9dd22728b22c363cbe80cd9db. 

This basically just removes the hacks we tried to make the older framework function. Fixes multiple oddities, primarily crashes when quickly adding or removing presets and crazy CPU usage when the list of presets is larger than the visible area.

Note two other minor changes I noticed updating to the latest main, adding the publishing xml definition file and removing an unused dependency.