### PR TITLE
Create multiple waypoints at once from POIs

### DIFF
--- a/JAFDTC/UI/App/EditPointsOfInterestPage.xaml.cs
+++ b/JAFDTC/UI/App/EditPointsOfInterestPage.xaml.cs
@@ -48,7 +48,7 @@ namespace JAFDTC.UI.App
     /// item class for an item in the point of interest list view. this provides ui-friendly views of properties
     /// suitable for display in the ui via bindings.
     /// </summary>
-    internal class PoIListItem
+    public class PoIListItem
     {
         public PointOfInterest PoI { get; set; }
 

--- a/JAFDTC/UI/Base/AddNavpointsFromPOIsPage.xaml
+++ b/JAFDTC/UI/Base/AddNavpointsFromPOIsPage.xaml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+**********************************************************************************************************************
+    
+AddNavpointsFromPOIsPage.xaml : ui xaml point of interest navpoint addition
+Copyright(C) 2023-5 ilominar/raven, fizzle
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
+Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+You should have received a copy of the GNU General Public License along with this program.  If not, see
+https://www.gnu.org/licenses/.
+
+    {ThemeResource SystemAccentColor}
+    
+**********************************************************************************************************************
+-->
+<Page
+    x:Class="JAFDTC.UI.Base.AddNavpointsFromPOIsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:JAFDTC.UI.App"
+    xmlns:ui_ctk="using:CommunityToolkit.WinUI"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Page.Resources>
+
+        <!-- brush for error fields. -->
+        <SolidColorBrush x:Key="ErrorFieldBorderBrush" Color="DarkRed"/>
+        <SolidColorBrush x:Key="ErrorFieldBackgroundBrush" Color="PaleVioletRed"/>
+
+    </Page.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <!--
+        ===============================================================================================================
+        row 0 : controls
+        ===============================================================================================================
+        -->
+        <Grid Grid.Row="0"
+              HorizontalAlignment="Center" VerticalAlignment="Center">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- poi search box -->
+            <AutoSuggestBox Grid.Column="0" Width="375" x:Name="uiPoINameFilterBox"
+                            VerticalAlignment="Center"
+                            PlaceholderText="Filter Points of Interest by Name"
+                            QueryIcon="Find"
+                            TextChanged="PoINameFilterBox_TextChanged"
+                            QuerySubmitted="PoINameFilterBox_QuerySubmitted"/>
+
+            <!-- command bar -->
+            <CommandBar Grid.Column="1" Margin="6,0,0,0"
+                        HorizontalAlignment="Left" VerticalAlignment="Center">
+                <AppBarToggleButton x:Name="uiBarBtnFilter" Label="Filter Points"
+                                    Click="CmdFilter_Click"
+                                    ToolTipService.ToolTip="Set filter to apply to points of interest">
+                    <AppBarToggleButton.Icon>
+                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE71C;"/>
+                    </AppBarToggleButton.Icon>
+                </AppBarToggleButton>
+                <AppBarSeparator/>
+                <CommandBar.SecondaryCommands>
+                    <AppBarButton x:Name="uiBarBtnCoords" Label="Coordinate Format"
+                                  Click="CmdCoords_Click"
+                                  ToolTipService.ToolTip="Select format for coordinates">
+                        <AppBarButton.Icon>
+                            <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE909;"/>
+                        </AppBarButton.Icon>
+                    </AppBarButton>
+                </CommandBar.SecondaryCommands>
+            </CommandBar>
+        </Grid>
+
+        <!--
+        ===============================================================================================================
+        row 1 : list and header
+        ===============================================================================================================
+        -->
+        <Grid Grid.Row="1" Margin="0,6,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <Grid Grid.Row="0" Margin="16,0,12,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="24"/>
+                    <ColumnDefinition Width="120"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="130"/>
+                    <ColumnDefinition Width="130"/>
+                    <ColumnDefinition Width="110"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="1" Margin="0,0,0,0"
+                           HorizontalTextAlignment="Center"
+                           Style="{StaticResource TableHeaderTextStyle}">
+                    Theater
+                </TextBlock>
+                <TextBlock Grid.Column="2" Margin="6,0,0,0"
+                           HorizontalTextAlignment="Left"
+                           Style="{StaticResource TableHeaderTextStyle}"
+                           Text="Point of Interest Name and Tags"/>
+                <TextBlock Grid.Column="3" Margin="6,0,0,0"
+                           HorizontalTextAlignment="Center"
+                           Style="{StaticResource TableHeaderTextStyle}"
+                           Text="Latitude"/>
+                <TextBlock Grid.Column="4" Margin="6,0,0,0"
+                           HorizontalTextAlignment="Center"
+                           Style="{StaticResource TableHeaderTextStyle}"
+                           Text="Longitude"/>
+                <TextBlock Grid.Column="5" Margin="6,0,0,0"
+                           HorizontalTextAlignment="Center"
+                           Style="{StaticResource TableHeaderTextStyle}"
+                           Text="Elevation (ft)"/>
+            </Grid>
+
+            <ListView Grid.Row="1" x:Name="uiPoIListView"
+                      SelectionMode="Extended"
+                      SelectionChanged="uiPoIListView_SelectionChanged"
+                      ItemsSource="{x:Bind CurPoIItems}">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="local:PoIListItem">
+                        <Grid Margin="6">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="24"/>
+                                <ColumnDefinition Width="120"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="130"/>
+                                <ColumnDefinition Width="130"/>
+                                <ColumnDefinition Width="110"/>
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock Grid.Column="0"
+                                       VerticalAlignment="Center"
+                                       HorizontalTextAlignment="Center"
+                                       FontFamily="Segoe Fluent Icons"
+                                       Text="{x:Bind Glyph}"/>
+                            <TextBlock Grid.Column="1"
+                                       VerticalAlignment="Center"
+                                       HorizontalTextAlignment="Center"
+                                       Text="{x:Bind PoI.Theater, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"/>
+                            <StackPanel Grid.Column="2"
+                                        VerticalAlignment="Center">
+                                <TextBlock HorizontalTextAlignment="Left"
+                                           FontSize="16"
+                                           FontWeight="Medium"
+                                           Text="{x:Bind PoI.Name, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"/>
+                                <TextBlock HorizontalTextAlignment="Left"
+                                           FontSize="12"
+                                           FontStyle="Italic"
+                                           Foreground="{StaticResource TextFillColorTertiary}"
+                                           Text="{x:Bind TagsUI}">
+                                </TextBlock>
+                            </StackPanel>
+                            <TextBlock Grid.Column="3" Margin="6,0,0,0"
+                                       VerticalAlignment="Center"
+                                       HorizontalTextAlignment="Center"
+                                       Text="{x:Bind LatUI}"/>
+                            <TextBlock Grid.Column="4" Margin="6,0,0,0"
+                                       VerticalAlignment="Center"
+                                       HorizontalTextAlignment="Center"
+                                       Text="{x:Bind LonUI}"/>
+                            <TextBlock Grid.Column="5" Margin="6,0,0,0"
+                                       VerticalAlignment="Center"
+                                       HorizontalTextAlignment="Center"
+                                       Text="{x:Bind PoI.Elevation, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"/>
+                        </Grid>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </Grid>
+
+        <!--
+        ===============================================================================================================
+        row 2 : buttons
+        ===============================================================================================================
+        -->
+        <Grid Grid.Row="2" Margin="24,12,24,15">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="110"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Button Grid.Column="3" Margin="20,0,0,0" x:Name="uiAcceptBtnCancel"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Center"
+                    Click="AcceptBtnCancel_Click"
+                    ToolTipService.ToolTip="Return to navpoint editor without adding POIs">
+                Cancel
+            </Button>
+            <Button Grid.Column="4" Margin="20,0,0,0" x:Name="uiAcceptBtnOK"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Center"
+                    Click="AcceptBtnOk_Click"
+                    ToolTipService.ToolTip="Append all listed POIs as navpoints">
+                Append All
+            </Button>
+        </Grid>
+
+    </Grid>
+</Page>

--- a/JAFDTC/UI/Base/AddNavpointsFromPOIsPage.xaml.cs
+++ b/JAFDTC/UI/Base/AddNavpointsFromPOIsPage.xaml.cs
@@ -1,0 +1,384 @@
+// ********************************************************************************************************************
+//
+// AddNavpointsFromPOIsPage.xaml.cs : ui c# point of navpoint addition
+//
+// Copyright(C) 2023-5 ilominar/raven, fizzle
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
+// Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program.  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// ********************************************************************************************************************
+
+using JAFDTC.Models;
+using JAFDTC.Models.DCS;
+using JAFDTC.UI.App;
+using JAFDTC.Utilities;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text.RegularExpressions;
+
+namespace JAFDTC.UI.Base
+{
+    /// <summary>
+    /// TODO: document
+    /// </summary>
+    public sealed partial class AddNavpointsFromPOIsPage : Page
+    {
+        /// <summary>
+        /// return an object to use as the argument to the add POI navpoints editor. this object is passed in through the
+        /// Parameter of a navigation operation.
+        /// </summary>
+        public class NavigationArg
+        {
+            public Page ParentEditor { get; private set; }
+            public IConfiguration Config { get; private set; }
+            public IEditNavpointListPageHelper PageHelper { get; private set; }
+            public NavigationArg(Page parentEditor, IConfiguration config, IEditNavpointListPageHelper helper) => 
+                (ParentEditor, Config, PageHelper) = (parentEditor, config, helper);
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // properties
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        private ObservableCollection<App.PoIListItem> CurPoIItems { get; set; }
+
+        private List<PointOfInterest> CurPoI { get; set; }
+
+        private LLFormat LLDisplayFmt { get; set; }
+
+        private string FilterTheater { get; set; }
+
+        private string FilterCampaign { get; set; }
+
+        private string FilterTags { get; set; }
+
+        private PointOfInterestTypeMask FilterIncludeTypes { get; set; }
+
+        private bool IsFiltered => !(string.IsNullOrEmpty(FilterTheater) &&
+                                     string.IsNullOrEmpty(FilterCampaign) && 
+                                     string.IsNullOrEmpty(FilterTags) &&
+                                     FilterIncludeTypes.HasFlag(PointOfInterestTypeMask.DCS_CORE) &&
+                                     FilterIncludeTypes.HasFlag(PointOfInterestTypeMask.USER) &&
+                                     FilterIncludeTypes.HasFlag(PointOfInterestTypeMask.CAMPAIGN));
+
+        private NavigationArg NavArgs;
+
+        // read-only properties
+
+        private readonly Dictionary<LLFormat, int> _llFmtToIndexMap;
+        private readonly Dictionary<string, LLFormat> _llFmtTextToFmtMap;
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // construction
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        public AddNavpointsFromPOIsPage()
+        {
+            InitializeComponent();
+
+            CurPoIItems = new ObservableCollection<App.PoIListItem>();
+
+            // NOTE: these need to be kept in sync with PoIDetails and the xaml.
+            //
+            _llFmtToIndexMap = new Dictionary<LLFormat, int>()
+            {
+                [LLFormat.DDU] = 0,
+                [LLFormat.DMS] = 1,
+                [LLFormat.DDM_P3ZF] = 2
+            };
+            _llFmtTextToFmtMap = new Dictionary<string, LLFormat>()
+            {
+                ["Decimal Degrees"] = LLFormat.DDU,
+                ["Degrees, Minutes, Seconds"] = LLFormat.DMS,
+                ["Degrees, Decimal Minutes"] = LLFormat.DDM_P3ZF,
+            };
+
+            LLDisplayFmt = LLFormat.DDM_P3ZF;
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // ui utility
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        /// <summary>
+        /// return a list of points of interest matching the current filter configuration with a name that
+        /// containst the provided name fragment.
+        /// </summary>
+        private List<PointOfInterest> GetPoIsMatchingFilter(string name = null)
+        {
+            PointOfInterestDbQuery query = new(FilterIncludeTypes, FilterTheater, FilterCampaign, name, FilterTags,
+                                               PointOfInterestDbQueryFlags.NAME_PARTIAL_MATCH);
+            return PointOfInterestDbase.Instance.Find(query, true);
+        }
+
+        /// <summary>
+        /// update the coordinate format used in the poi lat/lon specification. there are per-format fields to
+        /// deal with the apparent inability to change masks dynamically. show the field for the current format,
+        /// hide all others. updates LLDisplayFmt.
+        /// </summary>
+        private void ChangeCoordFormat(LLFormat fmt)
+        {
+            LLDisplayFmt = fmt;
+        }
+
+        /// <summary>
+        /// rebuild the content of the point of interest list based on the current contents of the poi database
+        /// along with the currently selected theater, tags, and included types from the filter specification.
+        /// name specifies the partial name to match, null if no match on name.
+        /// </summary>
+        private void RebuildPoIList(string name = null)
+        {
+            CurPoI = GetPoIsMatchingFilter(name);
+            CurPoIItems.Clear();
+            foreach (PointOfInterest poi in CurPoI)
+                CurPoIItems.Add(new App.PoIListItem(poi, LLDisplayFmt));
+            UpdateAcceptButtons();
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // ui interactions
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        private void uiPoIListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            UpdateAcceptButtons();
+        }
+
+        private void UpdateAcceptButtons()
+        {
+            ToolTip tip = new ToolTip();
+            int remainingCount = NavArgs.PageHelper.NavptRemainingCount(NavArgs.Config);
+            if (uiPoIListView.SelectedItems.Count > 0)
+            {
+                uiAcceptBtnOK.Content = "Append Selected";
+                if (uiPoIListView.SelectedItems.Count > remainingCount)
+                {
+                    uiAcceptBtnOK.IsEnabled = false;
+                    tip.Content = $"The airframe has space for only {remainingCount} more {NavArgs.PageHelper.NavptName.ToLower()}s";
+                }
+                else
+                {
+                    uiAcceptBtnOK.IsEnabled = true;
+                    tip.Content = $"Append {uiPoIListView.SelectedItems.Count} selected POIs as {NavArgs.PageHelper.NavptName.ToLower()}s";
+                }
+            }
+            else
+            {
+                uiAcceptBtnOK.Content = "Append All";
+                if (CurPoIItems.Count > remainingCount)
+                {
+                    uiAcceptBtnOK.IsEnabled = false;
+                    tip.Content = $"The airframe has space for only {remainingCount} more {NavArgs.PageHelper.NavptName.ToLower()}s";
+                }
+                else
+                {
+                    uiAcceptBtnOK.IsEnabled = true;
+                    tip.Content = $"Append {CurPoIItems.Count} listed POIs as {NavArgs.PageHelper.NavptName.ToLower()}s";
+                }
+            }
+            ToolTipService.SetToolTip(uiAcceptBtnOK, tip);
+        }
+
+        // ---- buttons -----------------------------------------------------------------------------------------------
+
+        /// <summary>
+        /// accept click: if page has errors and we aren't linked, update the configuration state before returning to
+        /// the navpoint list.
+        /// </summary>
+        private async void AcceptBtnOk_Click(object sender, RoutedEventArgs args)
+        {
+            if (uiPoIListView.SelectedItems.Count > 0)
+            {
+                ContentDialogResult result = await Utilities.Message2BDialog(
+                    Content.XamlRoot,
+                    "Append Selected?",
+                    $"Are you sure you want to append {uiPoIListView.SelectedItems.Count} selected POIs as {NavArgs.PageHelper.NavptName}s?",
+                    $"Append Selected"
+                );
+                if (result == ContentDialogResult.Primary)
+                {
+                    List<PointOfInterest> pois = new List<PointOfInterest>(uiPoIListView.SelectedItems.Count);
+                    foreach (App.PoIListItem item in uiPoIListView.SelectedItems)
+                        pois.Add(item.PoI);
+                    NavArgs.PageHelper.AppendFromPOIsToConfig(pois, NavArgs.Config);
+                    Frame.GoBack();
+                }
+            }
+            else
+            {
+                ContentDialogResult result = await Utilities.Message2BDialog(
+                    Content.XamlRoot,
+                    "Append All?",
+                    $"Are you sure you want to append all {CurPoIItems.Count} listed POIs as {NavArgs.PageHelper.NavptName}s?",
+                    $"Append All"
+                );
+                if (result == ContentDialogResult.Primary)
+                {
+                    List<PointOfInterest> pois = new List<PointOfInterest>(CurPoIItems.Count);
+                    foreach (App.PoIListItem item in CurPoIItems)
+                        pois.Add(item.PoI);
+                    NavArgs.PageHelper.AppendFromPOIsToConfig(pois, NavArgs.Config);
+                    Frame.GoBack();
+                }
+            }
+        }
+
+        /// <summary>
+        /// accept cancel click: return to the navpoint list without making any changes to the navpoint.
+        /// </summary>
+        private void AcceptBtnCancel_Click(object sender, RoutedEventArgs args)
+        {
+            Frame.GoBack();
+        }
+
+        // ---- name search box ---------------------------------------------------------------------------------------
+
+        /// <summary>
+        /// filter box text changed: update the items in the search box based on the value in the field.
+        /// </summary>
+        private void PoINameFilterBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+        {
+            if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
+            {
+                List<string> suitableItems = new();
+                List<PointOfInterest> pois = GetPoIsMatchingFilter(sender.Text);
+                if (pois.Count == 0)
+                    suitableItems.Add("No Matching Points of Interest Found");
+                else
+                    foreach (PointOfInterest poi in pois)
+                        suitableItems.Add(poi.Name);
+                sender.ItemsSource = suitableItems;
+            }
+        }
+
+        /// <summary>
+        /// filter box query submitted: apply the query text filter to the pois listed in the poi list.
+        /// </summary>
+        private void PoINameFilterBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+        {
+            RebuildPoIList(args.QueryText);
+        }
+
+        // ---- command bar / commands --------------------------------------------------------------------------------
+
+        /// <summary>
+        /// filter command click: setup the filter setup.
+        /// </summary>
+        private async void CmdFilter_Click(object sender, RoutedEventArgs args)
+        {
+            AppBarToggleButton button = (AppBarToggleButton)sender;
+            if (button.IsChecked != IsFiltered)
+                button.IsChecked = IsFiltered;
+
+            GetPoIFilterDialog filterDialog = new(FilterTheater, FilterCampaign, FilterTags, FilterIncludeTypes)
+            {
+                XamlRoot = Content.XamlRoot,
+                Title = $"Set a Filter for Points of Interest",
+                PrimaryButtonText = "Set",
+                SecondaryButtonText = "Clear Filters",
+                CloseButtonText = "Cancel",
+            };
+            ContentDialogResult result = await filterDialog.ShowAsync(ContentDialogPlacement.Popup);
+            if (result == ContentDialogResult.Primary)
+            {
+                FilterTheater = filterDialog.Theater;
+                FilterCampaign = filterDialog.Campaign;
+                FilterTags = PointOfInterest.SanitizedTags(filterDialog.Tags);
+                FilterIncludeTypes = filterDialog.IncludeTypes;
+            }
+            else if (result == ContentDialogResult.Secondary)
+            {
+                FilterTheater = "";
+                FilterCampaign = "";
+                FilterTags = "";
+                FilterIncludeTypes = PointOfInterestTypeMask.ANY;
+            }
+            else
+            {
+                return;                                         // EXIT: cancelled, no change...
+            }
+
+            button.IsChecked = IsFiltered;
+
+            Settings.LastPoIFilterTheater = FilterTheater;
+            Settings.LastPoIFilterCampaign = FilterCampaign;
+            Settings.LastPoIFilterTags = FilterTags;
+            Settings.LastPoIFilterIncludeTypes = FilterIncludeTypes;
+
+            uiPoIListView.SelectedItems.Clear();
+            RebuildPoIList();
+        }
+
+        // ---- coordinate setup --------------------------------------------------------------------------------------
+
+        /// <summary>
+        /// select coordinate format click: present the user with a list dialog to select the display format for poi
+        /// coordinates and update the ui to reflect the new choice.
+        /// </summary>
+        private async void CmdCoords_Click(object sender, RoutedEventArgs args)
+        {
+            List<string> items = new(_llFmtTextToFmtMap.Keys);
+            GetListDialog coordList = new(items, null, 0, _llFmtToIndexMap[LLDisplayFmt])
+            {
+                XamlRoot = Content.XamlRoot,
+                Title = "Select a Coordinate Format",
+                PrimaryButtonText = "OK",
+                CloseButtonText = "Cancel"
+            };
+            ContentDialogResult result = await coordList.ShowAsync(ContentDialogPlacement.Popup);
+            if (result == ContentDialogResult.Primary)
+            {
+                Settings.LastPoICoordFmtSelection = _llFmtTextToFmtMap[coordList.SelectedItem];
+                ChangeCoordFormat(_llFmtTextToFmtMap[coordList.SelectedItem]);
+                RebuildPoIList();
+            }
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        //
+        // events
+        //
+        // ------------------------------------------------------------------------------------------------------------
+
+        /// <summary>
+        /// on navigating to/from this page, set up and tear down our internal and ui state based on the configuration
+        /// we are editing.
+        /// </summary>
+        protected override void OnNavigatedTo(NavigationEventArgs args)
+        {
+            NavArgs = (NavigationArg)args.Parameter;
+
+            FilterTheater = Settings.LastPoIFilterTheater;
+            FilterCampaign = Settings.LastPoIFilterCampaign;
+            FilterTags = Settings.LastPoIFilterTags;
+            FilterIncludeTypes = Settings.LastPoIFilterIncludeTypes;
+            uiBarBtnFilter.IsChecked = IsFiltered;
+
+            ChangeCoordFormat(Settings.LastPoICoordFmtSelection);
+            RebuildPoIList();
+
+            base.OnNavigatedTo(args);
+        }
+    }
+}

--- a/JAFDTC/UI/Base/EditNavpointListPage.xaml
+++ b/JAFDTC/UI/Base/EditNavpointListPage.xaml
@@ -75,6 +75,13 @@ https://www.gnu.org/licenses/.
                     <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE7B7;"/>
                 </AppBarButton.Icon>
             </AppBarButton>
+            <AppBarButton x:Name="uiBarImportPOIs" Label="Add From POIs"
+                          Click="CmdImportPOIs_Click"
+                          ToolTipService.ToolTip="Add multiple navpoints from POIs">
+                <AppBarButton.Icon>
+                    <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xECAF;"/>
+                </AppBarButton.Icon>
+            </AppBarButton>
             <AppBarButton x:Name="uiBarImport" Icon="Download" Label="Import"
                           Click="CmdImport_Click"
                           ToolTipService.ToolTip="Import navpoints from a file"/>

--- a/JAFDTC/UI/Base/EditNavpointListPage.xaml.cs
+++ b/JAFDTC/UI/Base/EditNavpointListPage.xaml.cs
@@ -311,6 +311,17 @@ namespace JAFDTC.UI.Base
         /// <summary>
         /// TODO: document
         /// </summary>
+        private void CmdImportPOIs_Click(object sender, RoutedEventArgs args)
+        {
+            SaveEditStateToConfig();
+            NavArgs.BackButton.IsEnabled = false;
+            Frame.Navigate(typeof(AddNavpointsFromPOIsPage), new AddNavpointsFromPOIsPage.NavigationArg(this, Config, PageHelper),
+                new SlideNavigationTransitionInfo() { Effect = SlideNavigationTransitionEffect.FromRight });
+        }
+
+        /// <summary>
+        /// TODO: document
+        /// </summary>
         private async void CmdImport_Click(object sender, RoutedEventArgs args)
         {
             if (await NavpointUIHelper.Import(Content.XamlRoot, PageHelper.AirframeType,

--- a/JAFDTC/UI/Base/EditWaypointListHelperBase.cs
+++ b/JAFDTC/UI/Base/EditWaypointListHelperBase.cs
@@ -1,0 +1,39 @@
+﻿using JAFDTC.Models;
+using JAFDTC.Models.A10C;
+using JAFDTC.Models.Base;
+using JAFDTC.Models.DCS;
+using JAFDTC.Utilities.Networking;
+using Microsoft.UI.Xaml.Controls;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JAFDTC.UI.Base
+{
+    internal abstract class EditWaypointListHelperBase : IEditNavpointListPageHelper
+    {
+        public abstract string SystemTag { get; }
+        public abstract string NavptListTag { get; }
+        public abstract AirframeTypes AirframeType { get; }
+        public virtual string NavptName => "Waypoint";
+        public virtual Type NavptEditorType => typeof(EditNavpointPage);
+        public abstract int NavptMaxCount { get; }
+
+        public abstract int NavptCurrentCount(IConfiguration config);
+        public virtual int NavptRemainingCount(IConfiguration config) => NavptMaxCount - NavptCurrentCount(config);
+        public abstract void AddNavpoint(IConfiguration config);
+        public abstract void AppendFromPOIsToConfig(IEnumerable<PointOfInterest> pois, IConfiguration config);
+        public abstract void CaptureNavpoints(IConfiguration config, WyptCaptureDataRx.WyptCaptureData[] wypts, int startIndex);
+        public abstract void CopyConfigToEdit(IConfiguration config, ObservableCollection<INavpointInfo> edit);
+        public abstract bool CopyEditToConfig(ObservableCollection<INavpointInfo> edit, IConfiguration config);
+        public abstract string ExportNavpoints(IConfiguration config);
+        public abstract object NavptEditorArg(Page parentEditor, IConfiguration config, int indexNavpt);
+        public abstract INavpointSystemImport NavptSystem(IConfiguration config);
+        public abstract bool PasteNavpoints(IConfiguration config, string cbData, bool isReplace = false);
+        public abstract void ResetSystem(IConfiguration config);
+        public virtual void SetupUserInterface(IConfiguration config, ListView listView) { }
+    }
+}

--- a/JAFDTC/UI/Base/IEditNavpointListPageHelper.cs
+++ b/JAFDTC/UI/Base/IEditNavpointListPageHelper.cs
@@ -21,6 +21,7 @@ using JAFDTC.Models;
 using JAFDTC.Models.Base;
 using Microsoft.UI.Xaml.Controls;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
 using static JAFDTC.Utilities.Networking.WyptCaptureDataRx;
@@ -66,6 +67,16 @@ namespace JAFDTC.UI.Base
         public int NavptMaxCount { get; }
 
         /// <summary>
+        /// return the  number of navpoints currently configured.
+        /// </summary>
+        public int NavptCurrentCount(IConfiguration config);
+
+        /// <summary>
+        /// return the  number of navpoints that can be added before reaching the maximum.
+        /// </summary>
+        public int NavptRemainingCount(IConfiguration config);
+
+        /// <summary>
         /// set up the user interface for the navpoint list editor. this method is called at OnNavigatedTo. 
         /// </summary>
         public void SetupUserInterface(IConfiguration config, ListView listView);
@@ -79,6 +90,8 @@ namespace JAFDTC.UI.Base
         /// TODO: document
         /// </summary>
         public bool CopyEditToConfig(ObservableCollection<INavpointInfo> edit, IConfiguration config);
+
+        public void AppendFromPOIsToConfig(IEnumerable<Models.DCS.PointOfInterest> pois, IConfiguration config);
 
         /// <summary>
         /// TODO: document

--- a/JAFDTC/UI/M2000C/M2000CEditWaypointListHelper.cs
+++ b/JAFDTC/UI/M2000C/M2000CEditWaypointListHelper.cs
@@ -18,6 +18,7 @@
 // ********************************************************************************************************************
 
 using JAFDTC.Models;
+using JAFDTC.Models.A10C;
 using JAFDTC.Models.Base;
 using JAFDTC.Models.FA18C;
 using JAFDTC.Models.M2000C;
@@ -39,7 +40,7 @@ namespace JAFDTC.UI.M2000C
     /// helper class for EditNavpointListPage that implements IEditNavpointListPageHelper. this handles the
     /// specialization of the generate navpoint list page for the m-2000c airframe.
     /// </summary>
-    internal class M2000CEditWaypointListHelper : IEditNavpointListPageHelper
+    internal class M2000CEditWaypointListHelper : EditWaypointListHelperBase
     {
         public static ConfigEditorPageInfo PageInfo
             => new(WYPTSystem.SystemTag, "Waypoints", "WYPT", Glyphs.WYPT,
@@ -51,17 +52,13 @@ namespace JAFDTC.UI.M2000C
         //
         // ------------------------------------------------------------------------------------------------------------
 
-        public string SystemTag => WYPTSystem.SystemTag;
+        public override string SystemTag => WYPTSystem.SystemTag;
 
-        public string NavptListTag => WYPTSystem.WYPTListTag;
+        public override string NavptListTag => WYPTSystem.WYPTListTag;
 
-        public AirframeTypes AirframeType => AirframeTypes.M2000C;
+        public override AirframeTypes AirframeType => AirframeTypes.M2000C;
 
-        public string NavptName => "Waypoint";
-
-        public Type NavptEditorType => typeof(EditNavpointPage);
-
-        public int NavptMaxCount => 10;
+        public override int NavptMaxCount => 10;
 
         // ------------------------------------------------------------------------------------------------------------
         //
@@ -69,9 +66,9 @@ namespace JAFDTC.UI.M2000C
         //
         // ------------------------------------------------------------------------------------------------------------
 
-        public void SetupUserInterface(IConfiguration config, ListView listView) { }
+        public override int NavptCurrentCount(IConfiguration config) => ((M2000CConfiguration)config).WYPT.Count;
 
-        public void CopyConfigToEdit(IConfiguration config, ObservableCollection<INavpointInfo> edit)
+        public override void CopyConfigToEdit(IConfiguration config, ObservableCollection<INavpointInfo> edit)
         {
             M2000CConfiguration a10cConfig = (M2000CConfiguration)config;
             edit.Clear();
@@ -81,43 +78,62 @@ namespace JAFDTC.UI.M2000C
             }
         }
 
-        public bool CopyEditToConfig(ObservableCollection<INavpointInfo> edit, IConfiguration config)
+        public override bool CopyEditToConfig(ObservableCollection<INavpointInfo> edit, IConfiguration config)
         {
-            M2000CConfiguration a10cConfig = (M2000CConfiguration)config;
-            a10cConfig.WYPT.Points.Clear();
+            M2000CConfiguration m2kConfig = (M2000CConfiguration)config;
+            m2kConfig.WYPT.Points.Clear();
             foreach (WaypointInfo wypt in edit.Cast<WaypointInfo>())
             {
-                a10cConfig.WYPT.Points.Add(new WaypointInfo(wypt));
+                m2kConfig.WYPT.Points.Add(new WaypointInfo(wypt));
             }
             return true;
         }
 
-        public INavpointSystemImport NavptSystem(IConfiguration config)
+        public override void AppendFromPOIsToConfig(IEnumerable<Models.DCS.PointOfInterest> pois, IConfiguration config)
+        {
+            M2000CConfiguration m2kConfig = (M2000CConfiguration)config;
+            ObservableCollection<WaypointInfo> points = m2kConfig.WYPT.Points;
+            int startNumber = (points.Count == 0) ? 1 : points[^1].Number + 1;
+            foreach (Models.DCS.PointOfInterest poi in pois)
+            {
+                WaypointInfo wypt = new()
+                {
+                    Number = startNumber++,
+                    Name = poi.Name,
+                    Lat = poi.Latitude,
+                    Lon = poi.Longitude,
+                    Alt = poi.Elevation
+                };
+                m2kConfig.WYPT.Points.Add(new WaypointInfo(wypt));
+            }
+        }
+
+        public override INavpointSystemImport NavptSystem(IConfiguration config)
         {
             return ((M2000CConfiguration)config).WYPT;
         }
 
-        public void ResetSystem(IConfiguration config)
+        public override void ResetSystem(IConfiguration config)
         {
             ((M2000CConfiguration)config).WYPT.Reset();
         }
 
-        public void AddNavpoint(IConfiguration config)
+        public override void AddNavpoint(IConfiguration config)
         {
             ((M2000CConfiguration)config).WYPT.Add();
         }
 
-        public bool PasteNavpoints(IConfiguration config, string cbData, bool isReplace = false)
+        public override bool PasteNavpoints(IConfiguration config, string cbData, bool isReplace = false)
         {
             return ((M2000CConfiguration)config).WYPT.ImportSerializedNavpoints(cbData, isReplace);
         }
 
-        public string ExportNavpoints(IConfiguration config)
+        public override string ExportNavpoints(IConfiguration config)
         {
             return ((M2000CConfiguration)config).WYPT.SerializeNavpoints();
         }
 
-        public void CaptureNavpoints(IConfiguration config, WyptCaptureData[] wypts, int startIndex)
+        public override void CaptureNavpoints(IConfiguration config, WyptCaptureData[] wypts, int startIndex)
         {
             WYPTSystem wyptSys = ((M2000CConfiguration)config).WYPT;
             for (int i = 0; i < wypts.Length; i++)
@@ -145,7 +161,7 @@ namespace JAFDTC.UI.M2000C
             }
         }
 
-        public object NavptEditorArg(Page parentEditor, IConfiguration config, int indexNavpt)
+        public override object NavptEditorArg(Page parentEditor, IConfiguration config, int indexNavpt)
         {
             bool isUnlinked = string.IsNullOrEmpty(config.SystemLinkedTo(SystemTag));
             return new EditNavptPageNavArgs(parentEditor, config, indexNavpt, isUnlinked, typeof(M2000CEditWaypointHelper));


### PR DESCRIPTION
Over the years I've been building up a list of POIs for the hundreds of targets on the Grayflag servers. I have them organized into campaigns, tagged by lattice and objective name, so I can find and add active objective areas as a group. This is kind of painful from the existing waypoint editor UI, adding one by one with like 6 clicks per WP. My workaround up to now was to export from the POIs UI to a file then import the file into the waypoint editor.

This change adds a UI to the waypoint editor to let you append multiple POIs at a time. It:

1. Retains the POI filters for browsing the POIs.
2. Lets you add the entire list shown, or select from it with shift and/or control.
3. Respects airframe maximum WP settings.

https://github.com/user-attachments/assets/96bcaf5b-3808-4632-ab5f-3b35000406b2