### PR TITLE
Make warning textboxes legible in dark mode

### DIFF
--- a/JAFDTC/AppResourceDict.xaml
+++ b/JAFDTC/AppResourceDict.xaml
@@ -75,8 +75,8 @@
     <SolidColorBrush x:Key="WarningFieldBorderBrush" Color="Orange"/>
     <SolidColorBrush x:Key="WarningFieldBackgroundBrush" Color="LightYellow"/>
     <Style x:Key="WarningTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource EditorParamEditTextBoxStyle}">
-		<Setter Property="Foreground" Value="{ThemeResource TextBoxForegroundThemeBrush}" />
-		<Setter Property="Background" Value="{ThemeResource WarningFieldBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{ThemeResource TextBoxForegroundThemeBrush}" />
+        <Setter Property="Background" Value="{ThemeResource WarningFieldBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{ThemeResource WarningFieldBorderBrush}" />
         <Setter Property="Template">
             <Setter.Value>

--- a/JAFDTC/AppResourceDict.xaml
+++ b/JAFDTC/AppResourceDict.xaml
@@ -75,7 +75,8 @@
     <SolidColorBrush x:Key="WarningFieldBorderBrush" Color="Orange"/>
     <SolidColorBrush x:Key="WarningFieldBackgroundBrush" Color="LightYellow"/>
     <Style x:Key="WarningTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource EditorParamEditTextBoxStyle}">
-        <Setter Property="Background" Value="{ThemeResource WarningFieldBackgroundBrush}" />
+		<Setter Property="Foreground" Value="{ThemeResource TextBoxForegroundThemeBrush}" />
+		<Setter Property="Background" Value="{ThemeResource WarningFieldBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{ThemeResource WarningFieldBorderBrush}" />
         <Setter Property="Template">
             <Setter.Value>


### PR DESCRIPTION
The warning textbox background I added a while back for waypoint length is illegible in dark mode:

(There's a long name here. You just can't see it because it's white on light yellow!)
<img width="986" height="583" alt="before" src="https://github.com/user-attachments/assets/626befb3-2a3c-4803-bedf-08bf15fceddd" />

Explicitly setting a foreground color for `WarningTextBoxStyle` fixes it:

<img width="970" height="575" alt="after" src="https://github.com/user-attachments/assets/68aa1e3d-5424-4d4c-9497-22e133bb55c8" />
