### PR TITLE
Feature: copy navpoints to POIs

### DIFF
--- a/JAFDTC/Models/DCS/PointOfInterestDbase.cs
+++ b/JAFDTC/Models/DCS/PointOfInterestDbase.cs
@@ -342,6 +342,8 @@ namespace JAFDTC.Models.DCS
         /// </summary>
         public int CountPoIInCampaign(string campaign)
         {
+            if (campaign == null)
+                return 0;
             PointOfInterestType type = PointOfInterestType.CAMPAIGN;
             return (_dbase.TryGetValue(type, out Dictionary<string, List<PointOfInterest>> dbType) &&
                     dbType.TryGetValue(campaign, out List<PointOfInterest> list)) ? list.Count : 0;

--- a/JAFDTC/UI/Base/AddNavpointsFromPOIsPage.xaml
+++ b/JAFDTC/UI/Base/AddNavpointsFromPOIsPage.xaml
@@ -206,19 +206,19 @@ https://www.gnu.org/licenses/.
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <Button Grid.Column="3" Margin="20,0,0,0" x:Name="uiAcceptBtnCancel"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Center"
-                    Click="AcceptBtnCancel_Click"
-                    ToolTipService.ToolTip="Return to navpoint editor without adding POIs">
-                Cancel
-            </Button>
-            <Button Grid.Column="4" Margin="20,0,0,0" x:Name="uiAcceptBtnOK"
+            <Button Grid.Column="3" Margin="20,0,0,0" x:Name="uiAcceptBtnOK"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Center"
                     Click="AcceptBtnOk_Click"
                     ToolTipService.ToolTip="Append all listed POIs as navpoints">
                 Append All
+            </Button>
+            <Button Grid.Column="4" Margin="20,0,0,0" x:Name="uiAcceptBtnCancel"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Center"
+                    Click="AcceptBtnCancel_Click"
+                    ToolTipService.ToolTip="Return to navpoint editor without adding POIs">
+                Cancel
             </Button>
         </Grid>
 

--- a/JAFDTC/UI/Base/EditNavpointListPage.xaml
+++ b/JAFDTC/UI/Base/EditNavpointListPage.xaml
@@ -87,12 +87,21 @@ https://www.gnu.org/licenses/.
                           Click="CmdImportPOIs_Click"
                           ToolTipService.ToolTip="Add multiple navpoints from POIs">
                 <AppBarButton.Icon>
-                    <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xECAF;"/>
+                    <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE826;"/>
                 </AppBarButton.Icon>
             </AppBarButton>
             <AppBarButton x:Name="uiBarImport" Icon="Download" Label="Import"
                           Click="CmdImport_Click"
                           ToolTipService.ToolTip="Import navpoints from a file"/>
+            <CommandBar.SecondaryCommands>
+                <AppBarButton x:Name="uiBarExportPOIs" Label="Save to POIs"
+                          Click="CmdExportPOIs_Click"
+                          ToolTipService.ToolTip="Copy navpoints to POIs">
+                    <AppBarButton.Icon>
+                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE7AC;"/>
+                    </AppBarButton.Icon>
+                </AppBarButton>
+            </CommandBar.SecondaryCommands>
         </CommandBar>
 
         <!--

--- a/JAFDTC/UI/Base/EditNavpointListPage.xaml.cs
+++ b/JAFDTC/UI/Base/EditNavpointListPage.xaml.cs
@@ -199,6 +199,7 @@ namespace JAFDTC.UI.Base
             Utilities.SetEnableState(uiBarImport, isEditable);
             Utilities.SetEnableState(uiBarMap, true);
             Utilities.SetEnableState(uiBarRenumber, isEditable && (EditNavpt.Count > 0));
+            Utilities.SetEnableState(uiBarExportPOIs, isEditable && (EditNavpt.Count > 0));
 
             uiNavptListView.CanReorderItems = isEditable;
             uiNavptListView.ReorderMode = (isEditable) ? ListViewReorderMode.Enabled : ListViewReorderMode.Disabled;
@@ -371,6 +372,62 @@ namespace JAFDTC.UI.Base
             NavArgs.BackButton.IsEnabled = false;
             Frame.Navigate(typeof(AddNavpointsFromPOIsPage), new AddNavpointsFromPOIsPage.NavigationArg(this, Config, PageHelper),
                 new SlideNavigationTransitionInfo() { Effect = SlideNavigationTransitionEffect.FromRight });
+        }
+
+        /// <summary>
+        /// export poi command: copy from current navpoints to POIs. Opens modal to prompt for campaign, tags, etc.
+        /// </summary>
+        private async void CmdExportPOIs_Click(object sender, RoutedEventArgs args)
+        {
+            if (uiNavptListView.Items.Count == 0)
+                return;
+            NavpointInfoBase navpt = uiNavptListView.Items[0] as NavpointInfoBase;
+            List<string> allowedTheaters = PointOfInterest.TheatersForCoords(navpt.Lat, navpt.Lon);
+
+            GetPoIFilterDialog filterDialog = new(
+                Settings.LastPoIFilterTheater, Settings.LastPoIFilterCampaign, Settings.LastPoIFilterTags,
+                mode: GetPoIFilterDialog.Mode.Choose, allowedTheaters: allowedTheaters)
+            {
+                XamlRoot = Content.XamlRoot,
+                Title = $"Copy to Points of Interest",
+                PrimaryButtonText = uiNavptListView.SelectedItems.Count > 0 ? "Copy Selected" : "Copy All",
+                CloseButtonText = "Cancel",
+            };
+            ContentDialogResult result = await filterDialog.ShowAsync(ContentDialogPlacement.Popup);
+            if (result == ContentDialogResult.Primary)
+            {
+                // Persist POI filters
+                Settings.LastPoIFilterTheater = filterDialog.Theater;
+                Settings.LastPoIFilterCampaign = filterDialog.Campaign;
+                Settings.LastPoIFilterTags = filterDialog.Tags;
+
+                // set common POI properties
+                PointOfInterestType poiType = PointOfInterestType.USER;
+                if (filterDialog.Campaign != null)
+                    poiType = PointOfInterestType.CAMPAIGN;
+
+                // get the list of navpoints to save as POIs
+                IList<object> itemsToExport = uiNavptListView.Items;
+                if (uiNavptListView.SelectedItems.Count > 0)
+                    itemsToExport = uiNavptListView.SelectedItems;
+
+                // save POIs
+                foreach (NavpointInfoBase nav in itemsToExport)
+                {
+                    PointOfInterestDbase.Instance.AddPointOfInterest(new()
+                    {
+                        Type = poiType,
+                        Theater = filterDialog.Theater,
+                        Campaign = filterDialog.Campaign,
+                        Tags = PointOfInterest.SanitizedTags(filterDialog.Tags),
+                        Name = nav.Name,
+                        Latitude = nav.Lat,
+                        Longitude = nav.Lon,
+                        Elevation = nav.Alt
+                    });
+                }
+                PointOfInterestDbase.Instance.Save(filterDialog.Campaign);
+            }
         }
 
         /// <summary>

--- a/JAFDTC/UI/Base/EditNavpointListPage.xaml.cs
+++ b/JAFDTC/UI/Base/EditNavpointListPage.xaml.cs
@@ -412,9 +412,10 @@ namespace JAFDTC.UI.Base
                     itemsToExport = uiNavptListView.SelectedItems;
 
                 // save POIs
+                List<string> dupes = new();
                 foreach (NavpointInfoBase nav in itemsToExport)
                 {
-                    PointOfInterestDbase.Instance.AddPointOfInterest(new()
+                    bool success = PointOfInterestDbase.Instance.AddPointOfInterest(new()
                     {
                         Type = poiType,
                         Theater = filterDialog.Theater,
@@ -425,8 +426,18 @@ namespace JAFDTC.UI.Base
                         Longitude = nav.Lon,
                         Elevation = nav.Alt
                     });
+                    if (!success)
+                        dupes.Add(nav.Name);
                 }
                 PointOfInterestDbase.Instance.Save(filterDialog.Campaign);
+
+                if (dupes.Count > 0)
+                {
+                    string dupeMsg = (dupes.Count == 1) ?
+                        $"The point of interest \"{dupes[0]}\" already exists and was not copied." :
+                        $"The following points of interest already exist and were not copied:\n- {string.Join("\n- ", dupes)}";
+                    await Utilities.Message1BDialog(Content.XamlRoot, "Duplicate Points of Interest", dupeMsg);
+                }
             }
         }
 


### PR DESCRIPTION
Now that we can copy multiple POIs to navpoints, it would be useful to be able to do the reverse. This implementation:

- supports adding the selection or the whole list
- re-uses the POI filter dialog to select the kind of POIs you're adding
- only allows adding to an appropriate theater
- prevents adding dupes

https://github.com/user-attachments/assets/ee861ac3-22d0-4a2d-bd2d-df7adca0d03e

Two closely related changes/fixes here you should know about:

1. fixed a bug preventing deletion of user POIs (8fc3ca3cf287478b98590a40f01f90dd6c83dbcf)
2. added a dictionary on `UniqueID` to prevent adding duplicate POIs (a8c6f48b11747f270461ba235da67196fa72ba84)

Before it's said and done, I wonder if we want `UniqueID` to include more facets of a navpoint. If it were me I might just make it a hash (SHA-1 probably) of campaign + theater + name + lat + long + altitude, but since you just added it, I didn't want to mess with it.