### PR TITLE
Fix export all vs. selected POIs

### DIFF
--- a/JAFDTC/UI/Base/EditNavpointListPage.xaml.cs
+++ b/JAFDTC/UI/Base/EditNavpointListPage.xaml.cs
@@ -380,12 +380,15 @@ namespace JAFDTC.UI.Base
         /// </summary>
         private void CmdExportPOIs_Click(object sender, RoutedEventArgs args)
         {
-            if ((uiNavptListView.Items.Count > 0) && (uiNavptListView.SelectedItems.Count == 0))
-                NavpointUIHelper.CopyNavpointsAsPoIs(Content.XamlRoot,
-                                                     [.. uiNavptListView.SelectedItems.OfType<INavpointInfo>() ], true);
-            else if (uiNavptListView.Items.Count > 0)
-                NavpointUIHelper.CopyNavpointsAsPoIs(Content.XamlRoot,
-                                                     [.. uiNavptListView.Items.OfType<INavpointInfo>() ], false);
+            if (uiNavptListView.Items.Count > 0)
+            {
+                if (uiNavptListView.SelectedItems.Count == 0)
+                    NavpointUIHelper.CopyNavpointsAsPoIs(Content.XamlRoot,
+                                                         [.. uiNavptListView.Items.OfType<INavpointInfo>()], true);
+                else
+                    NavpointUIHelper.CopyNavpointsAsPoIs(Content.XamlRoot,
+                                                         [.. uiNavptListView.SelectedItems.OfType<INavpointInfo>()], false);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Logic was reversed, exporting all when something was selected, selected when nothing was selected.